### PR TITLE
Documentation - Running minute on Uppmax

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ The FASTQ base name refers to files within the `fastq/` folder. The suffixes
 The `config.yaml` is used to configure everything else. Create a copy of the
 example `config.yaml` and edit it to suit your needs.
 
-## Running on Uppmax
+## Running on SLURM clusters (Uppmax in Sweden)
 
 Snakemake supports running on HPC environments. As such, it is possible to
-run minute on Uppmax. Handling of `config.yaml` and `experiment.tsv` files
+run minute on SLURM clusters, including the Swedish UPPMAX clusters. Handling
+of `config.yaml` and `experiment.tsv` files
 will work the same. You just need to have conda available
-and an active minute environment that you can install like described in the
+and an active minute environment that you can install as described in the
 **setup** section.
 
-**Note:** creating a Conda environment can be a lengthy process (this is
-apparently an [ongoing issue for Conda](https://www.anaconda.com/understanding-and-improving-condas-performance/).
+**Note:** creating a Conda environment on a shared filesystem can be a
+lengthy process.
 It is not advised to run this on a login node. You can wrap your conda
 environment installation on a `sbatch` file and submit it to the queue.
 
@@ -81,7 +82,7 @@ config file with your defaults:
             project: "snicYYYY-NNN-N"
             jobname: "{rule}_{jobid}"
             
-Note that you can use rule-dependent parameters such as `rule` `jobid` and
+Note that you can use rule-dependent parameters such as `rule`, `jobid` and
 `threads`. Then you call `snakemake`:
 
         snakemake -p -s path/to/the/Snakefile --jobs 20 --cluster-config path/to/cluster.yaml --cluster 'sbatch -A {cluster.project} -t {cluster.time} -c {cluster.cpus} -e logs_slurm/{cluster.jobname}.err -o logs_slurm/{cluster.jobname}.out -J {cluster.jobname}'
@@ -90,9 +91,9 @@ The `project` field is required, as SLURM will not queue your jobs if they are
 not attached to a computing project. The `--jobs` parameter in the `snakemake`
 command limits the maximum number of jobs to be queued, and it's also required.
 
-In this example I have created a `logs_slurm` folder to output the
-stdout/stderr of each job (otherwise you get a bunch of `slurm-<jobid>.out` files
-in the working directory). If you want this behavior you need to create that
+In this example, separate log files for each job (stdout and stderr) are written
+to a `logs_slurm` folder (otherwise you get a bunch of `slurm-<jobid>.out` files
+in the working directory). If you want this behavior, you need to create that
 directory before running `snakemake`.
 
 You can also wrap your minute pipeline call in a `sbatch` file itself, so
@@ -104,5 +105,3 @@ the scheduler does not run on a login node:
   also queuing time.
 - Ask only for 1 core.
 - Make sure you call `conda init && conda activate minute` in the wrapper.
-
-


### PR DESCRIPTION
Some extra documentation on how to run on uppmax. Providing template `cluster.yaml` and `minute-uppmax.sbatch` files could be an option.