### PR TITLE
keep_unmapped set to False in single-end BAM

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -180,8 +180,10 @@ rule convert_to_single_end:
     input:
         bam="mapped/{library}.bam"
     run:
-        se_bam.convert_paired_end_to_single_end_bam(input.bam, output.bam)
-
+        se_bam.convert_paired_end_to_single_end_bam(
+            input.bam,
+            output.bam,
+            keep_unmapped=False)
 
 # TODO have a look at UMI-tools also
 rule mark_duplicates:


### PR DESCRIPTION
Tiny pull request to set the parameter `keep_unmapped` to `False`. After giving it some thought and talking to Simon it seems best to not keep reads that are unmapped in the deduplication step.

However, I decided to set this as parameter in the generation of single-end file, so the `BAM` file under `mapped/` still contains the unmapped reads, in case some statistics about that would be needed. Generally, I don't think they will, unless there is some troubleshooting to do - for instance, we get a very high amount of unmapped reads in an experiment and we want to dig into what happened.
