### PR TITLE
Run MultiQC

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -33,7 +33,9 @@ fastq_map = {
     groupby(sorted(libraries, key=lambda lib: lib.fastqbase), key=lambda lib: lib.fastqbase)
 }
 
-rule all:
+
+rule multiqc:
+    output: "multiqc_report.html"
     input:
         expand([
             "igv/{library.name}.bw",
@@ -45,6 +47,8 @@ rule all:
         expand("scaled/{library.name}.scaled.bw",
             library=[np.treatment for np in normalization_pairs]),
         "summaries/stats_summary.txt",
+    shell:
+        "multiqc ."
 
 
 rule clean:
@@ -66,6 +70,8 @@ rule clean:
         " summaries"
         " factors"
         " log"
+        " multiqc_report.html"
+        " multiqc_data"
 
 
 rule fastqc_input:

--- a/environment.yml
+++ b/environment.yml
@@ -15,4 +15,4 @@ dependencies:
   - umi_tools
   - fastqc
   - bedtools
-
+  - multiqc


### PR DESCRIPTION
Since MultiQC needs to be run after everything else, this replaces the `all` rule with a rule that runs MultiQC.

MultiQC can be customized in many ways by adding a configuration file, but none of that is done here at the moment. We will probably need to look at some reports for actual data to know what we need.

The report is simply stored in `multiqc_report.html`. For the moment, it felt as if a report is sufficiently important to not be put into a subdirectory, but we can move it to `reports/` or similar.

Closes #30