### PR TITLE
No longer generate .tdf files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -39,7 +39,6 @@ rule multiqc:
     input:
         expand([
             "igv/{library.name}.bw",
-            "igv/{library.name}.tdf",
             "stats/{library.name}.txt",
         ], library=libraries),
         expand("fastqc/{fastq}_R{read}_fastqc.html",
@@ -265,21 +264,6 @@ rule insert_size_metrics:
         " HISTOGRAM_FILE={output.pdf}"
         " MINIMUM_PCT=0.5"
         " STOP_AFTER=10000000"
-
-
-rule igvtools_count:
-    output:
-        tdf="igv/{library}.tdf"
-    input:
-        bam="restricted/{library}.bam",
-        chrom_sizes=config["chrom_sizes"]
-    shell:
-        "igvtools"
-        " count"
-        " --extFactor 60"
-        " {input.bam}"
-        " {output.tdf}"
-        " {input.chrom_sizes}"
 
 
 # TODO can genome_size be computed automatically?

--- a/config.yaml
+++ b/config.yaml
@@ -8,9 +8,6 @@ reference_fasta: "ref/mm9.fasta.gz"
 # Path to a BED file listing the regions to be excluded
 blacklist_bed: "dummy_blacklist.bed"
 
-# Chromosome lengths file (.chrom.sizes or .genome)
-chrom_sizes: "ref/mm9.chrom.sizes"
-
 # Effective genome size
 genome_size: 2150570000
 


### PR DESCRIPTION
Because the rule that creates them (igvtools count) was the only reason we needed a `.chrom.sizes` file, this also allows us to remove `chrom_sizes` from the configuration.

Close #24
Close #34