### PR TITLE
Pin Bowtie2 to a working version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,7 +7,8 @@ dependencies:
   - snakemake-minimal
   - samtools
   - cutadapt
-  - bowtie2
+  # The package for Bowtie2 2.4.1 creates VN: tag without value in SAM header
+  - bowtie2 =2.3.5.1
   - je-suite
   - igvtools
   - deeptools


### PR DESCRIPTION
Bowtie2 2.4.1, which we get otherwise at the moment, is packaged incorrectly in Bioconda, see <https://github.com/bioconda/bioconda-recipes/issues/22836>.

With this, we no longer get this error message from `je markdupes`:
```
htsjdk.samtools.SAMFormatException: Error parsing SAM header. Problem parsing @PG key:value pair.
```