### PR TITLE
Remove contamination sequence from R2 before mapping

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -339,7 +339,7 @@ rule extract_fragment_size:
         fragsize="restricted/{library}.fragsize.txt"
     run:
         with open(output.fragsize, "w") as f:
-            print(parse_insert_size_metrics(input.insertsizes)["median_insert_size"],
+            print(int(parse_insert_size_metrics(input.insertsizes)["median_insert_size"]),
                   file=f)
 
 


### PR DESCRIPTION
This adds a step in which Cutadapt is run to remove read pairs in which R2 contains the sequence "TTTTTCTTTTCTTTTTTCTTTTCCTTCCTTCTAA". The error tolerance is set quite high (15%) in order to allow up to 5 mismatches or indels.

Unlike suggested in #32, this step cannot be done while demultiplexing, and must be done before or afterwards. To improve performance, we could run it in a pipeline with the demultiplexing step, though. But that can be done later.

The sequence is currently hard-coded. As soon as it turns out there is a need to actually configure it, I will make it configurable.

See also discussion at  #32.
Closes #32