### PR TITLE
Reorganize directory layout

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -46,9 +46,7 @@ rule multiqc:
     input:
         expand([
             "bigwig/{library.name}.unscaled.bw",
-            "stats/{library.name}.txt",
             "bigwig/{library.sample}_pooled.unscaled.bw",
-            "stats/{library.sample}_pooled.txt",
         ], library=libraries),
         expand("fastqc/{fastq}_R{read}_fastqc.html",
             fastq=fastq_map.keys(), read=(1, 2)),
@@ -383,7 +381,7 @@ rule scaled_bigwig:
 
 rule stats:
     output:
-        txt="stats/{library}.txt"
+        txt="tmp/8-stats/{library}.txt"
     input:
         mapped_flagstat="tmp/4-mapped/{library}.flagstat.txt",
         metrics="tmp/6-dupmarked/{library}.metrics",
@@ -412,7 +410,7 @@ rule stats_summary:
     output:
         txt="summaries/stats_summary.txt"
     input:
-        expand("stats/{library.name}.txt", library=libraries) + expand("stats/{pool.name}.txt", pool=pools)
+        expand("tmp/8-stats/{library.name}.txt", library=libraries) + expand("tmp/8-stats/{pool.name}.txt", pool=pools)
     run:
         stats_summaries = [parse_stats_fields(st_file) for st_file in input]
 


### PR DESCRIPTION
- This moves all folders listed in #54 to a `tmp/` subfolder (except `stats`).
- It marks all large files in the `tmp/` subfolder as temporary.
- Subfolder names now include a numeric prefix which shows in which order the steps are done:
```
1-noumi
2-noadapters
3-barcodes
3-demultiplexed
4-mapped
5-mapped_se
6-dupmarked
7-dedup
8-stats
```
This is a bit annoying when steps have to be reordered or a new step is inserted in the middle, but I believe it is worth it because it makes it much easier to understand (both as user and developer) what is done in which order.
- `restricted` is renamed to `final`
- All `.bw` files are now in a `bigwig/` folder

Closes #54
Closes #49 

See also #33