### PR TITLE
Speed up Cutadapt runtimes by reduce compression levels

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -163,6 +163,7 @@ for fastq_base, libs in fastq_map.items():
         shell:
             "cutadapt"
             " -e 0.15"  # TODO determine from barcode length
+            " --compression-level=4"
             " -g file:{input.barcodes_fasta}"
             " -o {params.r1}"
             " -p {params.r2}"


### PR DESCRIPTION
- Use compression level 1 when removing contamination
- Use compression level 4 in demultiplexing