### PR TITLE
Move non-temporary files from tmp/ to a new stats/ dir

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -30,7 +30,7 @@ localrules:
     clean,
     barcodes,
     remove_exclude_regions,
-    compute_scaling_factors,
+    summarize_scaling_factors,
     extract_fragment_size,
     stats,
     stats_summary,
@@ -39,6 +39,7 @@ localrules:
     mark_pe_duplicates,
     samtools_index,
     samtools_flagstat,
+    samtools_flagstat_final,
     insert_size_metrics,
 
 


### PR DESCRIPTION
This moves all the files that are currently still in `tmp/`, but are actually not temporary files, into a separate `stats/` directory.

Since with this, no files remain in `tmp/` (unless `--notem` is used), Snakemake is actually smart enough to also delete the empty directories, so after the run, the `tmp/` directory automatically disappears, which is quite nice.

The only somewhat ugly thing is that I needed to duplicate the `samtools flagstat` rule.

Closes #58