### PR TITLE
Run tests on two cores

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -17,4 +17,4 @@ mkdir fastq && mv -- *.fastq.gz fastq/
 mkdir ref && mv ref.* ref/
 ( cd ref && bowtie2-build -q ref.fa.gz ref )
 
-snakemake -p -j 1 -s ../Snakefile "$@"
+snakemake -p -j 2 -s ../Snakefile "$@"


### PR DESCRIPTION
This reduces wall-clock runtime for the tests from 3m 15s to approx. 2m 30s on my machine.