### PR TITLE
Speed up demultiplexing by switching to Cutadapt 3

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -178,11 +178,13 @@ for fastq_base, libs in fastq_map.items():
             r1=lambda wildcards: "final/fastq/{name}_R1.fastq.gz",
             r2=lambda wildcards: "final/fastq/{name}_R2.fastq.gz",
             fastqbase=fastq_base,
+        threads: 4
         log:
             "log/3-demultiplexed/{fastqbase}.log".format(fastqbase=fastq_base)
         shell:
             "cutadapt"
-            " -e 0.15"  # TODO determine from barcode length
+            " -j {threads}"
+            " -e 1"
             " --compression-level=4"
             " -g file:{input.barcodes_fasta}"
             " -o {params.r1}"

--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - nomkl
   - snakemake-minimal
   - samtools
-  - cutadapt
+  - cutadapt >=3.0
   # The package for Bowtie2 2.4.1 creates VN: tag without value in SAM header
   - bowtie2 =2.3.5.1
   - je-suite


### PR DESCRIPTION
Even with some of the improvements discussed in #70, demultiplexing is still quite slow and one of the bottlenecks of the pipeline. I therefore took the time to make some changes in Cutadapt. With Cutadapt 3.0, which I released this week, it is now possible to run demultiplexing on multiple cores.

I tested this on 10 million reads of a real dataset (the one I also used for #80), and when using `-j 4`, the runtime went from 32.3 µs/read to 5.4 µs/read, giving a speedup by a factor of six (!).

The speedup is greater than 4 because Cutadapt switches to compressing data using an external `pigz` process as soon as multiple cores are specified. `pigz` is more efficient than using the gzip compression functions built into Python.

See #70