### PR TITLE
Use Snakemake groups feature

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -116,6 +116,7 @@ rule move_umi_to_header:
         umistring="N" * config['umi_length']
     log:
         "log/1-noumi/{name}.log"
+    group: "clean_reads"
     shell:
         "umi_tools"
         " extract"
@@ -139,6 +140,7 @@ rule remove_contamination:
         r2="tmp/1-noumi/{name}.2.fastq.gz",
     log:
         "log/2-noadapters/{name}.trimmed.log"
+    group: "clean_reads"
     shell:
         "cutadapt"
         " -j {threads}"


### PR DESCRIPTION
Recent Snakemake versions have a feature that [allows to put rules into groups that are submitted as a single job to the cluster]( https://snakemake.readthedocs.io/en/stable/snakefiles/rules.html#defining-groups-for-execution). In that way, queing time and load on the cluster (and perhaps frequency of failures) can be reduced.

For this to make sense, all rules in a group should have similar CPU and memory requirements. I looked at the DAG for our pipeline and identified two groups for now: duplicate marking and "read cleaning" (UMI/adapter removal). There are probably more places where groups can be used.

Groups are ignored when running the workflow locally, so this is not tested.