### PR TITLE
Improve samtools sort speed

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -238,7 +238,7 @@ rule bowtie2:
         " --fast"
         " 2> {log}"
         " "
-        "| samtools sort -o {output.bam} -"
+        "| samtools sort -@ {threads} -o {output.bam} -"
 
 
 rule pool_replicates:


### PR DESCRIPTION
The Bowtie2 rule currently runs Bowtie2 and samtools in a pipe where only Bowtie2 uses all available cores. This is fine in the beginning as long as Bowtie2 is running, but then when Bowtie2 has finished, samtools needs to merge all the temporary output files that it has created and then we have a moment in which only a single core is used.

This PR makes samtools also use multiple cores.