### PR TITLE
Run Bowtie2 with --reorder flag for better reproducibility

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -231,6 +231,7 @@ rule bowtie2:
     # - add RG header
     shell:
         "bowtie2"
+        " --reorder"
         " -p {threads}"
         " -x {config[bowtie_index_name]}"
         " -1 {input.r1}"


### PR DESCRIPTION
Without this flag, Bowtie is free to output the reads in the order it likes. With the `--reorder` option, it will reorder the reads to make sure that they are in the same order as the input.

Runtime goes up a bit (around 5% or so), but that is worth it IMO, and Bowtie2 is quite fast anyway, so it doesn’t matter that much.