### PR TITLE
Redirect some rule outputs to corresponding log files

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -97,10 +97,9 @@ rule fastqc_input:
     input:
         fastq="fastq/{name}.fastq.gz"
     log:
-        out="log/0-fastqc/{name}_fastqc.html.log",
-        err="log/0-fastqc/{name}_fastqc.html.err",
+        "log/0-fastqc/{name}_fastqc.html.log"
     shell:
-        "fastqc --extract -o reports/fastqc {input.fastq} > {log.out} 2> {log.err}"
+        "fastqc --extract -o reports/fastqc {input.fastq} > {log} 2>&1 "
 
 
 rule move_umi_to_header:


### PR DESCRIPTION
Small PR to redirect output of rules: `insert_size_metrics`, `mark_duplicates`, `fastqc_input` and `multiqc` to corresponding log files. These are somewhat verbose outputs to stdout/stderr and when running `snakemake` they clutter a bit the terminal output.

If run on SLURM, the outputs of these go to corresponding slurm output files. If something crashes it is less intuitive to find the error message in these logs.

I added a `log/0-fastqc/` directory, I felt like `0` was still available. But I can also shift the numbers. There is also the question on whether these logs are useful at all, they only output `%` of reads processed. If we don't want to keep them, I'd still redirect the output to `/dev/null` or something. That may potentially obscure some error messages, though.


