### PR TITLE
Adapt resources in mark_pe_duplicates step

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -37,7 +37,6 @@ localrules:
     stats_summary,
     convert_to_single_end,
     mark_duplicates,
-    mark_pe_duplicates,
     samtools_index,
     samtools_flagstat,
     samtools_flagstat_final,
@@ -275,12 +274,13 @@ rule mark_duplicates:
 
 rule mark_pe_duplicates:
     """Select duplicate-flagged alignments and mark them in the PE file"""
+    resources:
+        mem_mb = lambda wildcards, attempt: attempt * 6400
     output:
         bam=temp("tmp/7-dedup/{library}.bam")
     input:
         target_bam="tmp/4-mapped/{library}.bam",
         proxy_bam="tmp/6-dupmarked/{library}.bam"
-    group: "duplicate_marking"
     run:
         se_bam.mark_duplicates_by_proxy_bam(
             input.target_bam,


### PR DESCRIPTION
This is an attempt to fix #98, since we have had a real dataset where it was crashing on a 14GB BAM file.

1. Step `mark_pe_duplicates` is separated from `duplicate_marking` group, as memory requirements sometimes are different, and is a step that may crash. 
2. `mark_pe_duplicates` is no longer specified as local rule.
3. Memory resources are asked proportional to the amount of memory per cpu allocated on Uppmax times the attempt number (up to three on my configuration).

This is a bit Uppmax-specific, but I guess in general the fine tuning of the pipeline is, so I guess it's OK. I have tried this on Uppmax with a large file that would crash the step and it worked correctly. I did use snakemake-profiles in my configuration, and I am not sure 100% if this influences the test. According to the documentation these are all snakemake features so it should not. In any case, it is a working solution, as far as I know.