### PR TITLE
Use NextSeq trimming

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -120,6 +120,7 @@ rule remove_contamination:
         " --rename '{{id}}_{{r1.cut_prefix}} {{comment}}'"
         " -e 0.15"
         " -A TTTTTCTTTTCTTTTTTCTTTTCCTTCCTTCTAA"
+        " --nextseq-trim=20"
         " --discard-trimmed"
         " -o {output.r1}"
         " -p {output.r2}"


### PR DESCRIPTION
This fixes #107: All reads will be quality trimmed using the NextSeq-specific trimming option`--nextseq-trim` in Cutadapt.

At the moment, this will not only trim R2, but also R1 because Cutadapt does not allow setting the trimming thresholds for R1 and R2 separately. I’m adding that to Cutadapt, but in the meantime, I don’t think it’s a problem because very few bases in R1 are actually removed because of this (~1%), and one could argue that it is a good thing to remove low-quality ends even in R1.

