### PR TITLE
Alternative fix for stacktrace on --dry-run

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -37,7 +37,7 @@ class Replicate(Library):
         return f"{self.sample}_rep{self.replicate}"
 
     def has_umi(self) -> bool:
-        with xopen(f"final/demultiplexed/{self.name}_R1.fastq.gz") as f:
+        with xopen(f"fastq/{self.fastqbase}_R1.fastq.gz") as f:
             line = f.readline()
         return bool(re.search("_[ACGTNacgtn]+", line))
 
@@ -45,6 +45,11 @@ class Replicate(Library):
 @dataclass
 class MultiplexedReplicate(Replicate):
     barcode: str
+
+    def has_umi(self) -> bool:
+        # Demultiplexing and UMI removal are done at the same time in the pipeline, so
+        # we know that a replicate that needed demultiplexing has UMIs
+        return True
 
 
 @dataclass


### PR DESCRIPTION
With this, `has_umi()` is only run for the libraries that are not MultiplexedReplicates. Also, this now checks the files within `fastq/`. We cannot access files within `final/demultiplexed/` as they are created as part of the pipeline. In particular, they won’t exist when `--dry-run` is used, leading to the stacktrace.

This is an alternative to #118

Closes #115