### PR TITLE
Bump Bowtie to 2.4.4

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,7 @@ dependencies:
   - snakemake-minimal >=6.9.0
   - samtools >=1.13
   - cutadapt >=3.5
-  # The package for Bowtie2 2.4.1 creates VN: tag without value in SAM header
-  - bowtie2 =2.3.5.1
+  - bowtie2 >=2.4.4
   - je-suite >=2.0.RC
   - igvtools >=2.5.3
   - deeptools >=3.5.0
@@ -18,6 +17,6 @@ dependencies:
   - multiqc >=1.11
   - xopen >=1.2.0
   - sra-tools >=2.11.0
-  - r-base >=4.1.0
+  - r-base >=4.0.0
   - r-ggplot2 >=3.3.0
   - r-dplyr >=1.0.0


### PR DESCRIPTION
The reason for restricting the version to 2.3.5.1 was that the tool would
create incorrect VN tags in the SAM header, see #51. This bug has since
been fixed according to
https://github.com/bioconda/bioconda-recipes/issues/22836 .

(The upstream issue at https://github.com/BenLangmead/bowtie2/issues/301 was re-opened, though.)

I had to reduce R to 4.0 because otherwise there were version conflicts.

Closes #121