### PR TITLE
FastQC multiplexed libraries only

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -63,7 +63,7 @@ multiqc_inputs = (
         "reports/scaling_barplot.png",
         "reports/grouped_scaling_barplot.png",
     ]
-    + expand("reports/fastqc/{library.fastqbase}_R{read}_fastqc/fastqc_data.txt", library=libraries, read=(1, 2))
+    + expand("reports/fastqc/{library.fastqbase}_R{read}_fastqc/fastqc_data.txt", library=multiplexed_libraries, read=(1, 2))
     + expand("log/2-noadapters/{library.fastqbase}.trimmed.log", library=libraries)
     + expand("log/4-mapped/{maplib.name}.log", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
     + expand("stats/6-dupmarked/{maplib.name}.metrics", maplib=maplibs)


### PR DESCRIPTION
Small PR to generate FastQC reports only for multiplexed libraries. Resolves #123 