### PR TITLE
Allow the "exclude" setting to be empty

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -353,19 +353,29 @@ rule mark_pe_duplicates:
             output.bam)
 
 
+def exclude_bed(wildcards):
+    bed = references[wildcards.reference].exclude_bed
+    return str(bed) if bed else []
+
+
 rule remove_exclude_regions:
     output:
         bam="final/bam/{library}.{reference}.bam"
     input:
         bam="tmp/7-dedup/{library}.{reference}.bam",
-        bed=lambda wildcards: str(references[wildcards.reference].exclude_bed)
-    shell:
-        "bedtools"
-        " intersect"
-        " -v"
-        " -abam {input.bam}"
-        " -b {input.bed}"
-        " > {output.bam}"
+        bed=exclude_bed,
+    run:
+        if input.bed:
+            shell(
+                "bedtools"
+                " intersect"
+                " -v"
+                " -abam {input.bam}"
+                " -b {input.bed}"
+                " > {output.bam}"
+            )
+        else:
+            os.link(input.bam, output.bam)
 
 
 rule insert_size_metrics:

--- a/testdata/config.yaml
+++ b/testdata/config.yaml
@@ -8,12 +8,13 @@ references:
     # A matching Bowtie2 index must exist in the same location.
     fasta: "ref/ref1.fa.gz"
 
-    # Path to a BED file with regions to exclude
+    # Path to a BED file with regions to exclude.
+    # If this is empty, no regions are excluded.
     exclude: "exclude1.bed"
 
   small:
     fasta: "ref/ref2.fa.gz"
-    exclude: "exclude2.bed"
+    exclude:
 
 
 # Length of the 5' UMI

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import os
 import re
 import sys
 from collections import defaultdict
@@ -5,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from io import StringIO
 from itertools import groupby
-from typing import List, Iterable, Dict, Tuple
+from typing import List, Iterable, Dict, Tuple, Optional
 
 from xopen import xopen
 
@@ -19,7 +20,7 @@ class Reference:
     name: str
     fasta: Path
     bowtie_index: Path
-    exclude_bed: Path
+    exclude_bed: Optional[Path]
 
 
 @dataclass
@@ -148,7 +149,7 @@ def make_references(config) -> Dict[str, Reference]:
     references = dict()
     for name, ref in config.items():
         fasta = Path(ref["fasta"])
-        exclude_bed = Path(ref["exclude"])
+        exclude_bed = Path(ref["exclude"]) if ref["exclude"] else None
         try:
             bowtie_index = detect_bowtie_index_name(ref["fasta"])
         except FileNotFoundError as e:


### PR DESCRIPTION
With this change, if no BED file is provided, nothing will be excluded from the final BAM file. Instead of calling "bedtools intersect", the duplicate-marked BAM file is hard-linked to the final output.

One minor issue is that the BAI file is still recreated. If desired, I can look into this as well.

In contrast to what was suggested in #103, this hardlinks the file because a symlink would get stale as soon as the temporary `tmp/6-dupmarked/*.bam` files are deleted by Snakemake.

Closes #103