### PR TITLE
Allow whitespace as field separater in TSV files

### DIFF
--- a/minute/__init__.py
+++ b/minute/__init__.py
@@ -177,7 +177,7 @@ def read_tsv(path, columns: int) -> Iterable[List[str]]:
             line = line.strip()
             if line.startswith("#") or not line:
                 continue
-            fields = line.strip().split("\t")
+            fields = line.strip().split()
             if len(fields) != columns:
                 raise ParseError(
                     f"Expected {columns} tab-separated fields in {path}, but found {len(fields)}")

--- a/tests/test_minute.py
+++ b/tests/test_minute.py
@@ -3,7 +3,7 @@ from minute import read_tsv
 
 def test_read_tsv(tmp_path):
     tsv = tmp_path / "file.tsv"
-    tsv.write_text("a\tb\t\tc\t")
-    assert list(read_tsv(tsv, 4)) == [
-        ["a", "b", "", "c"],
+    tsv.write_text("a\t  b c\t")
+    assert list(read_tsv(tsv, 3)) == [
+        ["a", "b", "c"],
     ]


### PR DESCRIPTION
This closes #134.

*Edit: The below is now already merged, this PR is now only about allowing whitespaces in addition to tabs.*

---
I wanted to add a unit test, but noticed we didn’t have any, so this PR also contains some necessary restructuring:

* `utils.py` was renamed to `minute/__init__.py`, thus creating a new Python package named `minute`.
* `se_bam.py` was also moved into `minute/`.
* A unit test was added in `tests/test_minute.py`. To run test(s), `pytest` is needed, and it is now run from `test.sh`.

Briefly, how `pytests` works: It discovers tests automatically by looking for files named `test_*.py`, and then it simply runs all functions named `test_*` in those files. In the test functions, `assert` is used to verify the thing that is tested.

The restructuring was necessary so that I could import the function to test from the test file.