### PR TITLE
Expand pools

### DIFF
--- a/Snakefile
+++ b/Snakefile
@@ -72,7 +72,7 @@ multiqc_inputs = (
 bigwigs = (
     expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=maplibs)
     + expand("final/bigwig/{maplib.name}.scaled.bw",
-        maplib=flatten_scaling_groups(scaling_groups, controls=False))
+        maplib=flatten_scaling_groups(scaling_groups, expand_pools=False, controls=False))
 )
 
 


### PR DESCRIPTION
As requested in #137, this changes `maplibs` so that all replicates within pools are included as well.

Note that this PR is relative to the `no-pool-dedup` branch, so it will be merged into that branch when one os clicks "Merge", and then PR #138 can be merged.