### PR TITLE
Add barcode to read header when demultiplexing

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,7 +6,7 @@ dependencies:
   - nomkl
   - snakemake-minimal >=6.9.0
   - samtools >=1.13
-  - cutadapt >=3.5
+  - cutadapt >=3.7
   - bowtie2 >=2.4.4
   - je-suite >=2.0.RC
   - igvtools >=2.5.3

--- a/minute/Snakefile
+++ b/minute/Snakefile
@@ -199,6 +199,7 @@ for fastq_base, libs in map_fastq_prefix_to_list_of_libraries(multiplexed_librar
             " -e {config[max_barcode_errors]}"
             " --compression-level=4"
             " -g file:{input.barcodes_fasta}"
+            " --rename '{{header}} barcode={{r1.match_sequence}}'"
             " -o {params.r1}"
             " -p {params.r2}"
             " --discard-untrimmed"


### PR DESCRIPTION
Tests will fail because this requires Cutadapt 3.7, which isn’t on Bioconda, yet.

Closes #141