### PR TITLE
Extend reads in unscaled bigwig files

### DIFF
--- a/minute/Snakefile
+++ b/minute/Snakefile
@@ -402,6 +402,7 @@ rule unscaled_bigwig:
     input:
         bam="final/bam/{library}.{reference}.bam",
         bai="final/bam/{library}.{reference}.bai",
+        fragsize="stats/final/{library}.{reference}.fragsize.txt",
         genome_size="stats/genome.{reference}.size.txt",
     log:
         "log/final/{library}.{reference}.unscaled.bw.log"
@@ -411,6 +412,7 @@ rule unscaled_bigwig:
         " -p {threads}"
         " --normalizeUsing RPGC"
         " --effectiveGenomeSize $(< {input.genome_size})"
+        " --extendReads $(< {input.fragsize})"
         " -b {input.bam}"
         " -o {output.bw}"
         " --binSize 1"


### PR DESCRIPTION
Tiny PR to match unscaled bigWig file generation parameters to scaled.

It looks odd that unscaled bigWig files are treated as single-end when BAM files are paired-end anyways. Makes the profiles scaled/unscaled look slightly different in shape, when they only should be different in scale.

Resolves #112 