### PR TITLE
Add samtools stats to final report

### DIFF
--- a/minute/Snakefile
+++ b/minute/Snakefile
@@ -67,6 +67,7 @@ multiqc_inputs = (
     + expand("log/2-noadapters/{library.fastqbase}.trimmed.log", library=multiplexed_libraries)
     + expand("log/4-mapped/{maplib.name}.log", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
     + expand("stats/6-dupmarked/{maplib.name}.metrics", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
+    + expand("stats/final/{maplib.name}.idxstats.txt", maplib=[m for m in maplibs])
 )
 bigwigs = (
     expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=maplibs)
@@ -624,10 +625,10 @@ rule samtools_index:
 
 rule samtools_idxstats:
     output:
-        txt="stats/{name}.idxstats.txt"
+        txt="stats/final/{name}.idxstats.txt"
     input:
-        bam="tmp/{name}.bam",
-        bai="tmp/{name}.bai",
+        bam="final/bam/{name}.bam",
+        bai="final/bam/{name}.bai",
     shell:
         "samtools idxstats {input.bam} > {output.txt}"
 

--- a/minute/multiqc_config.yaml
+++ b/minute/multiqc_config.yaml
@@ -10,6 +10,7 @@ run_modules:
   - cutadapt
   - custom_content
   - bowtie2
+  - samtools
   - picard
   - deeptools
 
@@ -33,6 +34,14 @@ module_order:
       info: "Read mapping of demultiplexed reads with Bowtie2"
       path_filters:
         - "log/4-mapped/*.log"
+  - samtools:
+      name: "Samtools stats"
+      anchor: "samtools"
+      target: ""
+      info: "Extra statistics on final BAM files"
+      path_filters:
+        - "stats/final/*idxstats.txt"
+        - "stats/final/*flagstat.txt"
   - picard:
       path_filters:
         - "*.metrics"


### PR DESCRIPTION
As commented in #84 `idxstats` files were not being generated even though there is a rule for it.

I thought it would not hurt to have those statistics on the final report, and they don't take too long to generate, so I made it targets of the `multiqc` rule as suggested, and added those files to the `multiqc_config.yaml`. 

I additionally added the `flagstat.txt` files to the multiqc report as well.

Resolves #84