### PR TITLE
Set version number in setup.cfg

### DIFF
--- a/minute/__init__.py
+++ b/minute/__init__.py
@@ -10,8 +10,12 @@ from typing import List, Iterable, Dict, Tuple, Optional, Union, Set
 
 from xopen import xopen
 
+try:
+    from importlib.metadata import version as _version
+except ImportError:
+    from importlib_metadata import version as _version
 
-__version__ = "0.1"
+__version__ = _version("minute")
 
 
 class ParseError(Exception):

--- a/minute/__main__.py
+++ b/minute/__main__.py
@@ -10,9 +10,8 @@ from argparse import ArgumentParser
 
 import importlib.resources
 
-from . import cli
+from . import cli, __version__
 from .cli import CommandLineError
-from . import __version__
 
 
 logger = logging.getLogger(__name__)

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,8 @@ name = minute
 author = Minute authors
 author_email =
 url = https://github.com/NBISweden/minute/
-# description =
+description = MINUTE-ChIP data analysis workflow
+version = 0.1.0
 long_description = file: README.md
 long_description_content_type = text/markdown
 classifiers =
@@ -14,7 +15,9 @@ classifiers =
 python_requires = >=3.7
 packages = find:
 install_requires =
+    xopen
     ruamel.yaml
+    importlib_metadata; python_version<'3.8'
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
With this, the version number is set along with other metadata in `setup.cfg`.

Another option is to use [setuptools-scm](https://github.com/pypa/setuptools_scm/), which one can use to derive the version number from the Git repository itself, but we an do that later.