### PR TITLE
Better handling of minute init --input parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # minute Changelog
 
+## v0.4.1
+
+### Bug fixes
+
+* Handle missing/incorrect `--input` parameter values on `minute init`.
+
 ## v0.4.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/cli/init.py
+++ b/src/minute/cli/init.py
@@ -62,6 +62,9 @@ def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], i
         )
 
     if barcodes is not None:
+        if input is None:
+            raise CommandLineError("--input must be specified if --barcodes option is used")
+
         libraries = make_libraries_from_barcodes_and_reads(barcodes, reads)
         groups = make_groups_from_barcodes_and_reads(barcodes, reads, input)
         write_tsv(libraries, directory / "libraries.tsv")

--- a/src/minute/cli/init.py
+++ b/src/minute/cli/init.py
@@ -116,7 +116,12 @@ def make_groups_from_barcodes_and_reads(barcodes, reads_directory, input):
     FASTQ R1/R2 pair in the reads_directory; input must correspond to one file
     pair in the reads_directory.
     """
-    prefixes = [p for p in parse_library_prefixes(reads_directory) if p != input]
+    prefixes = parse_library_prefixes(reads_directory)
+    if input not in prefixes:
+        msg = f"input ({input}) must match a FASTQ file prefix, found: {prefixes}"
+        raise ValueError(msg)
+
+    prefixes = [p for p in prefixes if p != input]
     barcodes_info = list(read_tsv(barcodes, columns=4))
     barcodes_refmap = {bc[0]: bc[3] for bc in barcodes_info}
 

--- a/src/minute/cli/init.py
+++ b/src/minute/cli/init.py
@@ -66,7 +66,12 @@ def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], i
             raise CommandLineError("--input must be specified if --barcodes option is used")
 
         libraries = make_libraries_from_barcodes_and_reads(barcodes, reads)
-        groups = make_groups_from_barcodes_and_reads(barcodes, reads, input)
+
+        try:
+            groups = make_groups_from_barcodes_and_reads(barcodes, reads, input)
+        except ValueError as e:
+            raise CommandLineError(f"Invalid --input value: {e}")
+
         write_tsv(libraries, directory / "libraries.tsv")
         write_tsv(groups, directory / "groups.tsv")
 


### PR DESCRIPTION
I mistakenly left out validation of `--input` on `minute init`. So the command would run, and generate invalid `groups.tsv` file. So now:

- An error is printed if `--barcodes` is provided but `--input` is not.
- An error is printed if the value of `--input` does not match the prefix of any of the .fastq.gz files in the `--reads` directory.

I think the `make_groups_from_barcodes_and_reads` should be the function raising an exception if input is not valid, but I also think it is not so nice if the user gets an output with an entire Traceback and all, so I put it on a try/catch block, but still printed the message coming from it in a `CommandLineError`, which I am unsure if it is the best way to do.