### PR TITLE
Mapping quality parameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # minute Changelog
 
+## v0.5.0
+
+### Features
+
+* Added `mapping_quality` optional parameter to filter out reads under a certain
+mapping quality threshold. By default, this value is set to zero (keep all).
+* Added `mapping_quality_bigwig` specific to `mapq_bigwigs` new rule that
+generates both final unfiltered bigWigs and `mapq.bw` filtered bigWigs according
+to this parameter. By default, those filtered bigWigs are not generated.
+
 ## v0.4.1
 
 ### Bug fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.4.1"
+version = "0.5.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -68,7 +68,7 @@ multiqc_inputs = (
     + expand("reports/fastqc/{library.fastqbase}_R{read}_fastqc/fastqc_data.txt", library=multiplexed_libraries, read=(1, 2))
     + expand("log/2-noadapters/{library.fastqbase}.trimmed.log", library=multiplexed_libraries)
     + expand("log/4-mapped/{maplib.name}.log", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
-    + expand("stats/6-dupmarked/{maplib.name}.metrics", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
+    + expand("stats/7-dupmarked/{maplib.name}.metrics", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
     + expand("stats/final/{maplib.name}.insertsizes.txt", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
     + expand("stats/final/{maplib.name}.idxstats.txt", maplib=[m for m in maplibs])
 )
@@ -278,6 +278,19 @@ rule bowtie2:
         "| samtools sort -@ {threads} -o {output.bam} -"
 
 
+rule quality_filter_reads:
+    output:
+        bam=temp("tmp/5-mapq-filtered/{sample}_rep{replicate}.{reference}.bam")
+    input:
+        bam="tmp/4-mapped/{sample}_rep{replicate}.{reference}.bam"
+    run:
+        mapq = config.get("mapping_quality", 0)
+        if mapq == 0:
+            os.link(input.bam, output.bam)
+        else:
+            shell("samtools view -h -b {input.bam} -q {mapq} > {output.bam}")
+
+
 rule pool_replicates:
     output:
         bam="final/bam/{sample}_pooled.{reference}.bam"
@@ -296,9 +309,9 @@ rule pool_replicates:
 rule convert_to_single_end:
     """Convert SAM files to single-end for marking duplicates"""
     output:
-        bam=temp("tmp/5-mapped_se/{library}.bam")
+        bam=temp("tmp/6-mapped_se/{library}.bam")
     input:
-        bam="tmp/4-mapped/{library}.bam"
+        bam="tmp/5-mapq-filtered/{library}.bam"
     group: "duplicate_marking"
     run:
         se_bam.convert_paired_end_to_single_end_bam(
@@ -330,12 +343,12 @@ def dupmark_command(wildcards):
 rule mark_duplicates:
     """UMI-aware duplicate marking with je suite (or MarkDuplicates if UMIs are missing)"""
     output:
-        bam=temp("tmp/6-dupmarked/{maplib}.bam"),
-        metrics="stats/6-dupmarked/{maplib}.metrics"
+        bam=temp("tmp/7-dupmarked/{maplib}.bam"),
+        metrics="stats/7-dupmarked/{maplib}.metrics"
     input:
-        bam="tmp/5-mapped_se/{maplib}.bam"
+        bam="tmp/6-mapped_se/{maplib}.bam"
     log:
-        "log/6-dupmarked/{maplib}.bam.log"
+        "log/7-dupmarked/{maplib}.bam.log"
     group: "duplicate_marking"
     params: command=dupmark_command
     shell:
@@ -352,10 +365,10 @@ rule mark_pe_duplicates:
     resources:
         mem_mb = lambda wildcards, attempt: attempt * 6400
     output:
-        bam=temp("tmp/7-dedup/{library}.bam")
+        bam=temp("tmp/8-dedup/{library}.bam")
     input:
-        target_bam="tmp/4-mapped/{library}.bam",
-        proxy_bam="tmp/6-dupmarked/{library}.bam"
+        target_bam="tmp/5-mapq-filtered/{library}.bam",
+        proxy_bam="tmp/7-dupmarked/{library}.bam"
     run:
         se_bam.mark_duplicates_by_proxy_bam(
             input.target_bam,
@@ -372,7 +385,7 @@ rule remove_exclude_regions:
     output:
         bam="final/bam/{library}.{reference}.bam"
     input:
-        bam="tmp/7-dedup/{library}.{reference}.bam",
+        bam="tmp/8-dedup/{library}.{reference}.bam",
         bed=exclude_bed,
     run:
         if input.bed:
@@ -521,8 +534,9 @@ rule replicate_stats:
         txt="stats/9-stats/{library}.{reference}.txt"
     input:
         mapped_flagstat="stats/4-mapped/{library}.{reference}.flagstat.txt",
-        metrics="stats/6-dupmarked/{library}.{reference}.metrics",
-        dedup_flagstat="stats/7-dedup/{library}.{reference}.flagstat.txt",
+        mapq_flagstat="stats/5-mapq-filtered/{library}.{reference}.flagstat.txt",
+        metrics="stats/7-dupmarked/{library}.{reference}.metrics",
+        dedup_flagstat="stats/8-dedup/{library}.{reference}.flagstat.txt",
         final_flagstat="stats/final/{library}.{reference}.flagstat.txt",
         insertsizes="stats/final/{library}.{reference}.insertsizes.txt",
         demux_stats="stats/final/{library}.nreads.txt",
@@ -534,13 +548,14 @@ rule replicate_stats:
             )
         for flagstat, name in [
             (input.mapped_flagstat, "raw_mapped"),
+            (input.mapq_flagstat, "mapq_mapped"),
             (input.dedup_flagstat, "dedup_mapped"),
             (input.final_flagstat, "final_mapped"),
         ]:
             d[name] = parse_flagstat(flagstat).mapped_reads
 
         d["raw_demultiplexed"] = read_int_from_file(input.demux_stats)
-        
+
         # Note that here we use as total/unique single ended fragments, because we deduplicate
         # based on 1st mate. However if we used proper-pairs the result would be very similar,
         # since in any case the paired-end read is a single sequencing event.
@@ -567,7 +582,7 @@ rule pooled_stats:
                 library=f"{wildcards.library}_pooled",
                 reference=wildcards.reference
             )
-        for key in ["raw_demultiplexed", "raw_mapped", "dedup_mapped", "library_size", "percent_duplication"]:
+        for key in ["raw_demultiplexed", "raw_mapped", "mapq_mapped", "dedup_mapped", "library_size", "percent_duplication"]:
             d[key] = "."
         d["final_mapped"] = parse_flagstat(input.final_flagstat).mapped_reads
         d["insert_size"] = parse_insert_size_metrics(input.insertsizes)["median_insert_size"]
@@ -588,6 +603,7 @@ rule stats_summary:
             "reference",
             "raw_demultiplexed",
             "raw_mapped",
+            "mapq_mapped",
             "dedup_mapped",
             "final_mapped",
             "library_size",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -555,6 +555,7 @@ rule replicate_stats:
             d[name] = parse_flagstat(flagstat).mapped_reads
 
         d["raw_demultiplexed"] = read_int_from_file(input.demux_stats)
+        d["frac_mapq_filtered"] = (d["raw_mapped"] - d["mapq_mapped"]) / d["raw_mapped"]
 
         # Note that here we use as total/unique single ended fragments, because we deduplicate
         # based on 1st mate. However if we used proper-pairs the result would be very similar,
@@ -582,7 +583,7 @@ rule pooled_stats:
                 library=f"{wildcards.library}_pooled",
                 reference=wildcards.reference
             )
-        for key in ["raw_demultiplexed", "raw_mapped", "mapq_mapped", "dedup_mapped", "library_size", "percent_duplication"]:
+        for key in ["raw_demultiplexed", "raw_mapped", "mapq_mapped", "dedup_mapped", "library_size", "percent_duplication", "frac_mapq_filtered"]:
             d[key] = "."
         d["final_mapped"] = parse_flagstat(input.final_flagstat).mapped_reads
         d["insert_size"] = parse_insert_size_metrics(input.insertsizes)["median_insert_size"]
@@ -608,6 +609,7 @@ rule stats_summary:
             "final_mapped",
             "library_size",
             "percent_duplication",
+            "frac_mapq_filtered",
             "insert_size",
         ]
 

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -77,7 +77,11 @@ bigwigs = (
     + expand("final/bigwig/{maplib.name}.scaled.bw",
         maplib=flatten_scaling_groups(scaling_groups, controls=False))
 )
-
+mapping_quality_bigwigs = (
+    expand("final/bigwig/{maplib.name}.unscaled.mapq.bw", maplib=maplibs)
+    + expand("final/bigwig/{maplib.name}.scaled.mapq.bw",
+        maplib=flatten_scaling_groups(scaling_groups, controls=False))
+)
 
 rule final:
     input:
@@ -95,6 +99,13 @@ rule full:
     input:
         bigwigs,
         "reports/multiqc_report_full.html",
+
+
+rule mapq_bigwigs:
+    input:
+        bigwigs,
+        mapping_quality_bigwigs,
+        "reports/multiqc_report.html"
 
 
 rule no_bigwigs:
@@ -443,6 +454,32 @@ rule unscaled_bigwig:
         " 2> {log}"
 
 
+rule unscaled_mapq_bigwig:
+    output:
+        bw="final/bigwig/{library}.{reference}.unscaled.mapq.bw"
+    input:
+        bam="final/bam/{library}.{reference}.bam",
+        bai="final/bam/{library}.{reference}.bai",
+        fragsize="stats/final/{library}.{reference}.fragsize.txt",
+        genome_size="stats/genome.{reference}.size.txt",
+    log:
+        log="log/final/{library}.{reference}.unscaled.mapq.bw.log",
+        stdout="log/final/{library}.{reference}.unscaled.mapq.bw.out",
+    threads: 19
+    shell:
+        "bamCoverage"
+        " -p {threads}"
+        " --normalizeUsing RPGC"
+        " --effectiveGenomeSize $(< {input.genome_size})"
+        " --extendReads $(< {input.fragsize})"
+        " --minMappingQuality {config[mapping_quality_bigwig]}"
+        " -b {input.bam}"
+        " -o {output.bw}"
+        " --binSize 1"
+        " > {log.stdout}"
+        " 2> {log.log}"
+
+
 for group in scaling_groups:
     rule:
         output:
@@ -527,6 +564,31 @@ rule scaled_bigwig:
         " --bam {input.bam}"
         " -o {output.bw}"
         " 2> {log}"
+
+
+rule scaled_mapq_bigwig:
+    output:
+        bw="final/bigwig/{library}.scaled.mapq.bw"
+    input:
+        factor="stats/8-factors/{library}.factor.txt",
+        fragsize="stats/final/{library}.fragsize.txt",
+        bam="final/bam/{library}.bam",
+        bai="final/bam/{library}.bai",
+    threads: 19
+    log:
+        log="log/final/{library}.scaled.mapq.bw.log",
+        stdout="log/final/{library}.scaled.mapq.bw.out",
+    shell:
+        "bamCoverage"
+        " -p {threads}"
+        " --binSize 1"
+        " --extendReads $(< {input.fragsize})"
+        " --scaleFactor $(< {input.factor})"
+        " --minMappingQuality {config[mapping_quality_bigwig]}"
+        " --bam {input.bam}"
+        " -o {output.bw}"
+        " > {log.stdout}"
+        " 2> {log.log}"
 
 
 rule replicate_stats:

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -289,7 +289,7 @@ rule bowtie2:
         "| samtools sort -@ {threads} -o {output.bam} -"
 
 
-rule quality_filter_reads:
+rule filter_by_mapq:
     output:
         bam=temp("tmp/5-mapq-filtered/{sample}_rep{replicate}.{reference}.bam")
     input:
@@ -299,7 +299,7 @@ rule quality_filter_reads:
         if mapq == 0:
             os.link(input.bam, output.bam)
         else:
-            shell("samtools view -h -b {input.bam} -q {mapq} > {output.bam}")
+            shell("samtools view -q {mapq} -o {output.bam} {input.bam}")
 
 
 rule pool_replicates:

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -81,6 +81,9 @@ custom_data:
       percent_duplication:
         description: "Percentage duplication"
         format: "{:,.3f}"
+      frac_mapq_filtered:
+        description: "Fraction of (raw) aligned reads that was filtered by mapping quality"
+        format: "{:,.3f}"
       insert_size:
         description: "Insert size median"
         format: "{:,.0f}"
@@ -136,6 +139,7 @@ table_columns_placement:
     percent_duplication: 10
     insert_size: 12
     library_size: 13
+    frac_mapq_filtered: 13.5
     reference: 14
   scalinginfo:
     sample_name: 1

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -33,7 +33,7 @@ module_order:
       target: ""
       info: "Read mapping of demultiplexed reads with Bowtie2"
       path_filters:
-        - "log/4-mapped/*.log"
+        - "log/5-mapped/*.log"
   - samtools:
       name: "Samtools stats"
       anchor: "samtools"
@@ -68,6 +68,9 @@ custom_data:
         format: "{:,.0f}"
       raw_mapped:
         description: "Number of mapped reads"
+        format: "{:,.0f}"
+      mapq_mapped:
+        description: "Number of mapped reads after filtering for mapping quality"
         format: "{:,.0f}"
       dedup_mapped:
         description: "Number of reads mapped after deduplication"
@@ -126,6 +129,7 @@ table_columns_placement:
     library: 1
     raw_demultiplexed: 2.5
     raw_mapped: 3
+    mapq_mapped: 3.5
     dedup_mapped: 4
     final_mapped: 5
     demultiplexed: 6

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -29,3 +29,7 @@ max_barcode_errors: 1
 # Filter out reads under certain mapping quality (0: no filtering)
 mapping_quality: 0
 
+# If filtered_bigwigs rule is run, additional bigWig files are produced,
+# where reads with MQ lower than this value are filtered out. This parameter
+# is independent of mapping_quality parameter above.
+mapping_quality_bigwig: 20

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -28,3 +28,4 @@ max_barcode_errors: 1
 
 # Filter out reads under certain mapping quality (0: no filtering)
 mapping_quality: 0
+

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -25,3 +25,6 @@ fragment_size: 150
 
 # Allow this many errors in the barcode when demultiplexing
 max_barcode_errors: 1
+
+# Filter out reads under certain mapping quality (0: no filtering)
+mapping_quality: 0


### PR DESCRIPTION
This PR has two related though independent parameters (I am still not completely convinced about the naming of things - a bit convoluted):

1. `mapping_quality` parameter to filter reads in the alignment that are under a certain mapping quality (typically, so-called multimappers). This in turn affects the scaling, because it removes those reads from the final counts. Our experience is that this should not change dramatically the scaling, and when a user really wants to filter out those reads, they will probably also want to exclude them in the scaling.
2. `mapping_quality_bigwig` parameter specific to filter out reads in the alignment only to generate separate `mapq.bw` files that do not contain those reads. These would only be generated through an alternative rule `mapq_bigwigs` because it is costly and a very specific type of run.

The reason to keep those separate is that we sometimes want to have the ability to produce those filtered bigwigs, because we might want to take the multimappers into account for scaling, but then look at the signal on the flanking, more unique areas of repetitive regions.

The way these two parameters interact can become a bit absurd if used randomly, as I see, there are these two meaningful scenarios:
a) `mapping_quality` is `0` (the default) but `mapping_quality_bigwig` is ` >0` to look at those tracks but include all the reads for filtering (multimappers are considered valid reads for scaling).
b) `mapping quality` is a certain `>0` value, then there is no real point to specify `mapping_quality_bigwig` because reads are filtered from the beginning, final bigWigs will not have those reads, unless one wants to be even more restrictive with the `mapping_quality_bigwig`, but I don't see a scenario where this obviously applies.

Potentially we could check that these conditions hold, but maybe there are situations where one would want to play with that, so I would not enforce it.

Either way, to generate "further filtered bigwigs" the user would need to specify the rule `mapq_bigwigs` which is not the default. It is costly and generates many files, but these can also be generated later on if needed without re-running the main part of the pipeline.

I have given `mapping_quality` a default of zero, so this parameter is compatible with previous versions of `minute.yaml`. `mapping_quality_bigwig` has no default, because it is only triggered if the user explicitly calls for `mapq_bigwigs` rule.
