### PR TITLE
QC report improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # minute Changelog
 
+## v0.6.0
+
+### Features
+
+* Barcode representation barplots, final number of mapped reads and percentage
+of total.
+* Stats summary table is now separated in replicates and pool for easier reading.
+
+### Other
+* Minor: expanded library name column so it is now wider.
+* Automatic formatting of QC pass for insert size and duplication rates are 
+removed.
+
 ## v0.5.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -37,8 +37,9 @@ localrules:
     summarize_scaling_factors,
     extract_fragment_size,
     pooled_stats,
+    pooled_stats_summary,
     replicate_stats,
-    stats_summary,
+    replicate_stats_summary,
     convert_to_single_end,
     mark_duplicates,
     samtools_index,
@@ -62,6 +63,7 @@ multiqc_inputs = (
     [
         "reports/scalinginfo.txt",
         "reports/stats_summary.txt",
+        "reports/pooled_stats_summary.txt",
         "reports/scaling_barplot.png",
         "reports/grouped_scaling_barplot.png",
     ]
@@ -654,11 +656,11 @@ rule pooled_stats:
             print(*d.values(), sep="\t", file=f)
 
 
-rule stats_summary:
+rule replicate_stats_summary:
     output:
         txt="reports/stats_summary.txt"
     input:
-        expand("stats/9-stats/{maplib.name}.txt", maplib=maplibs)
+        expand("stats/9-stats/{maplib.name}.txt", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
     run:
         header = [
             "map_id",
@@ -672,6 +674,28 @@ rule stats_summary:
             "library_size",
             "percent_duplication",
             "frac_mapq_filtered",
+            "insert_size",
+        ]
+
+        with open(output.txt, "w") as f:
+            print(*header, sep="\t", file=f)
+            for stats_file in sorted(input):
+                summary = parse_stats_fields(stats_file)
+                row = [summary[k] for k in header]
+                print(*row, sep="\t", file=f)
+
+
+rule pooled_stats_summary:
+    output:
+        txt="reports/pooled_stats_summary.txt"
+    input:
+        expand("stats/9-stats/{maplib.name}.txt", maplib=[m for m in maplibs if isinstance(m.library, Pool)])
+    run:
+        header = [
+            "map_id",
+            "library",
+            "reference",
+            "final_mapped",
             "insert_size",
         ]
 

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -66,6 +66,8 @@ multiqc_inputs = (
         "reports/pooled_stats_summary.txt",
         "reports/scaling_barplot.png",
         "reports/grouped_scaling_barplot.png",
+        "reports/barcode_representation.png",
+        "reports/barcode_representation_perc.png"
     ]
     + expand("reports/fastqc/{library.fastqbase}_R{read}_fastqc/fastqc_data.txt", library=multiplexed_libraries, read=(1, 2))
     + expand("log/2-noadapters/{library.fastqbase}.trimmed.log", library=multiplexed_libraries)
@@ -525,7 +527,9 @@ rule summarize_scaling_factors:
 rule summary_scaled_barplots:
     output:
         plot=expand("reports/scaling_barplot.{ext}", ext=["png", "pdf"]),
-        grouped_plot=expand("reports/grouped_scaling_barplot.{ext}", ext=["png", "pdf"])
+        grouped_plot=expand("reports/grouped_scaling_barplot.{ext}", ext=["png", "pdf"]),
+        barcode_plot=expand("reports/barcode_representation.{ext}", ext=["png", "pdf"]),
+        barcode_plot_perc=expand("reports/barcode_representation_perc.{ext}", ext=["png", "pdf"])
     input:
         info="reports/scalinginfo.txt"
     script:

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -60,7 +60,7 @@ custom_data:
       namespace: "summary"
     headers:
       library:
-        description: "Library name"
+        description: "Library name plus replicate number"
       reference:
         description: "Reference to which reads were mapped"
       raw_demultiplexed:
@@ -171,4 +171,4 @@ table_columns_placement:
 
 table_columns_name:
   summary:
-    library: "library name"
+    library: "extended library name"

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -54,7 +54,7 @@ module_order:
 custom_data:
   summary:
     file_format: "tsv"
-    section_name: "Statistics summary"
+    section_name: "Replicates summary"
     pconfig:
       id: "summary"
       namespace: "summary"
@@ -90,6 +90,23 @@ custom_data:
       library_size:
         description: "Library size estimate"
         format: "{:,.0f}"
+  pools:
+    file_format: "tsv"
+    section_name: "Pools summary"
+    pconfig:
+      id: "pools"
+      namespace: "pools"
+    headers:
+      library:
+        description: "Library name"
+      reference:
+        description: "Reference to which reads were mapped"
+      final_mapped:
+        description: "Number of reads mapped after deduplication and blocklist filter"
+        format: "{:,.0f}"
+      insert_size:
+        description: "Insert size median"
+        format: "{:,.0f}"
   scalinginfo:
     file_format: "tsv"
     section_name: "Scaling factors"
@@ -120,6 +137,8 @@ custom_data:
 sp:
   summary:
     fn: "stats_summary.txt"
+  pools:
+    fn: "pooled_stats_summary.txt"
   scalinginfo:
     fn: "scalinginfo.txt"
   groupedscaling:

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -133,6 +133,12 @@ custom_data:
     section_name: "Minute scaled read stats"
   replicatescaling:
     section_name: "Minute scaled read stats - replicates only"
+  barcodes:
+    section_name: "Barcode representation"
+  barcodes_perc:
+    section_name: "Barcode representation (perc)"
+
+
 
 sp:
   summary:
@@ -145,6 +151,11 @@ sp:
     fn: "grouped_scaling_barplot.png"
   replicatescaling:
     fn: "scaling_barplot.png"
+  barcodes:
+    fn: "barcode_representation.png"
+  barcodes_perc:
+    fn: "barcode_representation_perc.png"
+
 
 table_columns_placement:       
   summary:

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -172,19 +172,3 @@ table_columns_placement:
 table_columns_name:
   summary:
     library: "library name"
-
-table_cond_formatting_rules:
-  percent_duplication:
-      pass:
-        - lt: 0.1
-      warn:
-        - gt: 0.1
-      fail:
-        - gt: 0.25
-  insert_size:
-        pass:
-          - gt: 130
-        warn:
-          - lt: 130
-        fail:
-          - lt: 100


### PR DESCRIPTION
Some reporting features added and some fixes:
- Minute replicates panel is now grouped by condition, so there is not so much text on larger replicate sets.
- Pool rows are separated from replicates in the stats summary tables.
- A stacked barcode representation plot is also added. This is also generated by R as it was too specific to make MultiQC make it, and it does not increase dependencies.
- Some cosmetic fixes to the report: No assumptions about insert size and dup rates, as this is kind of experiment-specific, and header for library name has been forced to be wider (this is an issue that comes from MultiQC but I have not been able to fix it in any other way).

By making this additional barcode plot I have struggled with a bunch of assumptions we make for the general use case (now `minute init --barcodes`), that allows me to infer a "condition" which is essentially a semantics attached to the library barcode, that is the same across IP pools. 

This could in some highly customized runs be different, but it would only affect the colors of these plots.
