### PR TITLE
Bump micromamba version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
     name: Run pipeline
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: mamba-org/setup-micromamba@v1
         with:
-            micromamba-version: '1.3.1-0'
+            micromamba-version: '1.5.6-0'
             environment-file: environment.yml
             environment-name: testenv
             create-args: pytest


### PR DESCRIPTION
Using the old version caused a warning in PR #179:
https://github.com/elsasserlab/minute/actions/runs/8019232476/job/21906704535?pr=179#step:3:11

The test failure is from MultiQC, that needs to be fixed later.