### PR TITLE
Fix MultiQC output file name

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -20,7 +20,9 @@ dependencies:
   - picard >=2.26.0
   - fastqc >=0.11.9
   - bedtools >=2.30.0
-  - multiqc >=1.13
+  # 'output_fn_name' configuration setting is broken in multiqc 1.18 and 1.19
+  # multiqc 1.20 conflicts with pysam
+  - multiqc =1.17
   - xopen >=1.2.0
   - sra-tools >=2.11.0
   - r-base >=4.0.0

--- a/src/minute/multiqc_config.yaml
+++ b/src/minute/multiqc_config.yaml
@@ -4,6 +4,8 @@ intro_text: ""
 show_analysis_paths: False
 skip_generalstats: true
 ignore_images: false
+output_fn_name: "multiqc_report.html"
+data_dir_name: "multiqc_data"
 
 run_modules:
   - fastqc


### PR DESCRIPTION
For some reason, MultiQC 1.18+ bases the output file name on the report title. To get the old behavior, one needs to configure the output file names explicitly.

This PR does not actually fix the issue at the moment because `output_fn_name` is broken in MultiQC 1.19 and MultiQC 1.20 is not yet available on Bioconda.