### PR TITLE
Link to GitHub repository in docs TOC

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,6 +7,7 @@ nav:
   - Installation: install.md
   - User guide: guide.md
   - Reference: reference.md
+  - GitHub repository: https://github.com/elsasserlab/minute
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
May I suggest adding a link to the GitHub repository in the left sidebar? I often find myself on documentation web sites for a project that I know must be hosted on GitHub, but it’s hard to find the link (to report an issue or maybe just to see how active the project is).

I know there’s a link directly on the start page under the "Links" heading but that is easily overlooked.