### PR TITLE
minute run initialization improvements

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,17 @@
 # minute Changelog
 
+## v0.7.0
+
+### Features
+
+* `minute init` now can accept a `--config` parameter to copy an already
+existing `minute.yaml` into the run directory.
+
+### Bug fixes
+
+* Improved parameter check of `minute init`. Now a directory will not be created
+if an error occurs.
+
 ## v0.6.0
 
 ### Features

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -53,10 +53,22 @@ Note that `inp_prefix` **must match one of the FASTQ read pairs** in your `fastq
 with symlinks to each FASTQ file in `path/to/fastq`, a template `minute.yaml`
 configuration file and `libraries.tsv`, `groups.tsv` files.
 
-4. Edit [`minute.yaml`](guide.md#the-minuteyaml-file) as required. References present in `barcodes.tsv` must be 
+      Optionally, if you have ran `minute` before in your system and you already
+have some `minute.yaml` configuration you want to reuse, you can specify it via
+the `--config` parameter. This will make a copy of the provided file in the 
+directory where `minute` will run.
+
+         minute init myexperiment \
+            --reads path/to/fastq \
+            --barcodes path/to/barcodes.tsv \
+            --input inp_prefix \
+            --config path/to/minute.yaml
+
+4. Edit [`minute.yaml`](guide.md#the-minuteyaml-file) if required. References present in `barcodes.tsv` must be 
 specified in it. For example, if you specify `mm39` as reference genome, there 
 must be a `mm39` entry in `minute.yaml` with paths to matching bowtie2 indexes
 and FASTA reference. 
+
 
 !!! Note
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -24,6 +24,12 @@ template configurations.
 
 Initialize a minute run. Parameters:
 
+#### Positional
+
+**`first`**. Path to the target directory where minute will run.
+
+#### Named
+
 **`--reads`** Path to the directory where the FASTQ file pairs are located.
 
 **`--barcodes`** Path to the barcodes.tsv file. If not provided, `init` will
@@ -32,6 +38,9 @@ not create libraries.tsv, groups.tsv files. Requires `--reads` to be provided.
 **`--input`** Prefix of the FASTQ file pair that corresponds to the Input sample.
 It must match a file pair in the path specified by `--reads`. Required if 
 `--barcodes` is provded.  
+
+**`--config`** Path to a `minute.yaml` file to reuse. It will be copied in the
+target directory.
 
 
 ### download

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -39,7 +39,7 @@ not create libraries.tsv, groups.tsv files. Requires `--reads` to be provided.
 It must match a file pair in the path specified by `--reads`. Required if 
 `--barcodes` is provded.  
 
-**`--config`** Path to a `minute.yaml` file to reuse. It will be copied in the
+**`--config`** Path to a `minute.yaml` file to reuse. It will be copied into the
 target directory.
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.6.0"
+version = "0.7.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/cli/init.py
+++ b/src/minute/cli/init.py
@@ -3,6 +3,7 @@ Create and initialize a new pipeline directory
 """
 import logging
 import os
+import shutil
 from pathlib import Path
 import importlib.resources
 from typing import Optional
@@ -30,6 +31,11 @@ def add_arguments(parser):
         type=str,
         help="Name of the input sample (FASTQ name without _R1/_R2)."
     )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        help="Optional minute.yaml file to use as configuration. If not provided, a template will be created."
+    )
     parser.add_argument("directory", type=Path, help="New pipeline directory to create")
 
 
@@ -39,7 +45,7 @@ def main(args, arguments):
     run_init(**vars(args))
 
 
-def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], input: Optional[str]):
+def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], input: Optional[str], config: Optional[Path]):
     if " " in str(directory):
         raise CommandLineError("The name of the pipeline directory must not contain spaces")
 
@@ -65,6 +71,11 @@ def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], i
         except ValueError as e:
             raise CommandLineError(f"Invalid --input value: {e}")
 
+    if config is not None:
+        if not os.path.isfile(config):
+            raise CommandLineError(f"--config '{config}' file not found")
+        
+
     try:
         directory.mkdir()
     except OSError as e:
@@ -77,13 +88,16 @@ def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], i
         write_tsv(libraries, directory / "libraries.tsv")
         write_tsv(groups, directory / "groups.tsv")
 
-    configuration = importlib.resources.read_text("minute", "minute.yaml")
-    with open(Path(directory) / "minute.yaml", "w") as f:
-        f.write(configuration)
+    if config is not None:
+        shutil.copyfile(config, directory / "minute.yaml")
+    else:
+        configuration = importlib.resources.read_text("minute", "minute.yaml")
+        with open(Path(directory) / "minute.yaml", "w") as f:
+            f.write(configuration)
 
     logger.info("Pipeline directory %s created", directory)
     logger.info(
-        'Edit %s/%s and run "cd %s && minute run" to start the analysis',
+        'Edit %s/%s if necessary and run "cd %s && minute run" to start the analysis',
         directory,
         "minute.yaml",
         directory,

--- a/src/minute/cli/init.py
+++ b/src/minute/cli/init.py
@@ -74,7 +74,6 @@ def run_init(directory: Path, reads: Optional[Path], barcodes: Optional[Path], i
     if config is not None:
         if not os.path.isfile(config):
             raise CommandLineError(f"--config '{config}' file not found")
-        
 
     try:
         directory.mkdir()

--- a/src/minute/minute.yaml
+++ b/src/minute/minute.yaml
@@ -18,7 +18,7 @@ references:
 
 
 # Length of the 5' UMI
-umi_length: 6
+umi_length: 8
 
 # Fragment length (insert size)
 fragment_size: 150


### PR DESCRIPTION
Some changes to the `minute init` command:

* Check the parameters before creating any files. Before, if a `minute init` run failed, it annoyingly left some created files so it was not possible to re-run immediately without manually removing the created directory.
* Add a parameter to copy an already existing `minute.yaml` to the run directory. After a while, this is something that I constantly end up doing manually, and always overwriting a template file feels strange, it feels more natural to include it in the initialization process.