### PR TITLE
Produce only bigWig for pools of replicates

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # minute Changelog
 
+## v0.8.0
+
+### Features
+
+* New target rule `pooled_only` to skip individual replicates and generate 
+bigwig tracks only for replicate pools.
+
 ## v0.7.0
 
 ### Features

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -78,3 +78,4 @@ to run.
 
 **`mapq_bigwigs`**. Produces extra bigWigs `mapq.bw` filtered by mapping quality.
 
+**`pooled_only`**. Produces only the bigWigs for the pooled replicates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -86,6 +86,11 @@ mapping_quality_bigwigs = (
     + expand("final/bigwig/{maplib.name}.scaled.mapq.bw",
         maplib=flatten_scaling_groups(scaling_groups, controls=False))
 )
+pool_bigwigs = (
+    expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=[m for m in maplibs if isinstance(m.library, Pool)])
+    + expand("final/bigwig/{maplib.name}.scaled.bw",
+        maplib=[m for m in flatten_scaling_groups(scaling_groups, controls=False) if isinstance(m.library, Pool)])
+)
 
 rule final:
     input:
@@ -103,6 +108,12 @@ rule full:
     input:
         bigwigs,
         "reports/multiqc_report_full.html",
+
+
+rule pooled_only:
+    input:
+        pool_bigwigs,
+        "reports/multiqc_report.html"
 
 
 rule mapq_bigwigs:

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -12,13 +12,14 @@ from minute import (
     parse_stats_fields,
     read_int_from_file,
     compute_genome_size,
-    get_replicates,
+    get_sample_replicates,
     format_metadata_overview,
     is_snakemake_calling_itself,
     map_fastq_prefix_to_list_of_libraries,
     make_references,
     flatten_scaling_groups,
     get_all_pools,
+    get_all_replicates,
     Pool,
     MultiplexedReplicate,
     estimate_library_size,
@@ -72,9 +73,9 @@ multiqc_inputs = (
     ]
     + expand("reports/fastqc/{library.fastqbase}_R{read}_fastqc/fastqc_data.txt", library=multiplexed_libraries, read=(1, 2))
     + expand("log/2-noadapters/{library.fastqbase}.trimmed.log", library=multiplexed_libraries)
-    + expand("log/4-mapped/{maplib.name}.log", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
-    + expand("stats/7-dupmarked/{maplib.name}.metrics", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
-    + expand("stats/final/{maplib.name}.insertsizes.txt", maplib=[m for m in maplibs if not isinstance(m.library, Pool)])
+    + expand("log/4-mapped/{maplib.name}.log", maplib=get_all_replicates(maplibs))
+    + expand("stats/7-dupmarked/{maplib.name}.metrics", maplib=get_all_replicates(maplibs))
+    + expand("stats/final/{maplib.name}.insertsizes.txt", maplib=get_all_replicates(maplibs))
     + expand("stats/final/{maplib.name}.idxstats.txt", maplib=[m for m in maplibs])
 )
 bigwigs = (
@@ -324,7 +325,7 @@ rule pool_replicates:
     input:
         bam_replicates=lambda wildcards: expand(
             "final/bam/{{sample}}_rep{replicate}.{{reference}}.bam",
-            replicate=get_replicates(libraries, wildcards.sample))
+            replicate=get_sample_replicates(libraries, wildcards.sample))
     run:
         if len(input.bam_replicates) == 1:
             os.link(input.bam_replicates[0], output.bam)

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -18,6 +18,7 @@ from minute import (
     map_fastq_prefix_to_list_of_libraries,
     make_references,
     flatten_scaling_groups,
+    get_all_pools,
     Pool,
     MultiplexedReplicate,
     estimate_library_size,
@@ -87,9 +88,9 @@ mapping_quality_bigwigs = (
         maplib=flatten_scaling_groups(scaling_groups, controls=False))
 )
 pool_bigwigs = (
-    expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=[m for m in maplibs if isinstance(m.library, Pool)])
+    expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=get_all_pools(maplibs))
     + expand("final/bigwig/{maplib.name}.scaled.bw",
-        maplib=[m for m in flatten_scaling_groups(scaling_groups, controls=False) if isinstance(m.library, Pool)])
+        maplib=get_all_pools(flatten_scaling_groups(scaling_groups, controls=False)))
 )
 
 rule final:

--- a/src/minute/__init__.py
+++ b/src/minute/__init__.py
@@ -167,6 +167,10 @@ def flatten_scaling_groups(groups: Iterable[ScalingGroup], controls: bool = True
                     yield maplib
 
 
+def get_all_pools(maplibs: Iterable[LibraryWithReference]) -> List[LibraryWithReference]:
+    return [m for m in maplibs if isinstance(m.library, Pool)]
+
+
 def make_references(config) -> Dict[str, Reference]:
     references = dict()
     for name, ref in config.items():

--- a/src/minute/__init__.py
+++ b/src/minute/__init__.py
@@ -171,6 +171,10 @@ def get_all_pools(maplibs: Iterable[LibraryWithReference]) -> List[LibraryWithRe
     return [m for m in maplibs if isinstance(m.library, Pool)]
 
 
+def get_all_replicates(maplibs: Iterable[LibraryWithReference]) -> List[LibraryWithReference]:
+    return [m for m in maplibs if not isinstance(m.library, Pool)]
+
+
 def make_references(config) -> Dict[str, Reference]:
     references = dict()
     for name, ref in config.items():
@@ -361,7 +365,7 @@ def detect_bowtie_index_name(fasta_path: str) -> Path:
     )
 
 
-def get_replicates(libraries, sample):
+def get_sample_replicates(libraries, sample):
     replicates = [lib.replicate for lib in libraries if lib.sample == sample]
     return replicates
 


### PR DESCRIPTION
This is a functionality we are sometimes interested in, when there is shallow sequencing for many replicates, it does not make much sense to produce bigWig tracks for each replicate, but the pool would still be useful to visualize.

Now I am thinking this generates some (perhaps) desirable combinations of outputs, where `mapq_bigwigs` could combine with this. On the other hand that scenario (`pooled_only` + `mapq_bigwigs`) might not be so frequent.

The alternative to have a more flexible output is to make both target rules configuration flags instead and then produce the target bigWig files dynamically according to them.