### PR TITLE
More customized alignment to reference including strobealign

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # minute Changelog
 
+## v0.9.0
+
+### Features
+
+* Bowtie2 run mode can be configured in `minute.yaml` to any of the bowtie2 
+accepted modes. Default is still `--fast`.
+* Optionally align reads with `strobealign` instead of `bowtie2`.
+* Add read group RG to output BAM headers and read group ID to individual
+alignments.
+
 ## v0.8.0
 
 ### Features

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -67,7 +67,7 @@ directory where `minute` will run.
 4. Edit [`minute.yaml`](guide.md#the-minuteyaml-file) if required. References present in `barcodes.tsv` must be 
 specified in it. For example, if you specify `mm39` as reference genome, there 
 must be a `mm39` entry in `minute.yaml` with paths to matching bowtie2 indexes
-and FASTA reference. 
+(if aligning with bowtie2) and FASTA reference.
 
 
 !!! Note
@@ -276,6 +276,14 @@ an editor, read through the comments and edit as required.
       # where reads with MQ lower than this value are filtered out. This parameter
       # is independent of mapping_quality parameter above.
       mapping_quality_bigwig: 20
+
+      # Aligner to use in the genome alignment step
+      # Valid options: bowtie2, strobealign
+      aligner: "bowtie2"
+
+      # Bowtie2 alignment mode:
+      # fast, fast-local, sensitive, sensitive-local, very-sensitive
+      bowtie2_mode: "fast"
 
 
 ## Downloading data from the Sequence Read Archive (SRA)

--- a/environment.yml
+++ b/environment.yml
@@ -14,6 +14,7 @@ dependencies:
   - cutadapt >=3.7
   # bowtie2 2.5.2 crashes on the tests
   - bowtie2 =2.5.1
+  - strobealign >= 0.13.0
   - je-suite >=2.0.RC
   - igvtools >=2.5.3
   - deeptools >=3.5.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -296,13 +296,14 @@ rule align_to_reference:
     run:
         aligner = config.get("aligner", "bowtie2")
         if aligner == "bowtie2":
+            bowtie_mode = config.get("bowtie2_mode", "fast")
             shell("bowtie2"
                   " --reorder"
                   " -p {threads}"
                   " -x {params.reference.bowtie_index}"
                   " -1 {input.r1}"
                   " -2 {input.r2}"
-                  " --fast"
+                  " --{bowtie_mode}"
                   " 2> {log}"
                   " "
                   "| samtools sort -@ {threads} -o {output.bam} -"

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -293,17 +293,23 @@ rule bowtie2:
     # - write uncompressed BAM?
     # - filter unmapped reads directly? (samtools view -F 4 or bowtie2 --no-unal)
     # - add RG header
-    shell:
-        "bowtie2"
-        " --reorder"
-        " -p {threads}"
-        " -x {params.index}"
-        " -1 {input.r1}"
-        " -2 {input.r2}"
-        " --fast"
-        " 2> {log}"
-        " "
-        "| samtools sort -@ {threads} -o {output.bam} -"
+    run:
+        aligner = config.get("aligner", "bowtie2")
+        if aligner == "bowtie2":
+            shell("bowtie2"
+                  " --reorder"
+                  " -p {threads}"
+                  " -x {params.index}"
+                  " -1 {input.r1}"
+                  " -2 {input.r2}"
+                  " --fast"
+                  " 2> {log}"
+                  " "
+                  "| samtools sort -@ {threads} -o {output.bam} -"
+            )
+        else:
+            msg = f"Unknown aligner: {aligner}. Valid choices: bowtie2"
+            raise ValueError(msg)
 
 
 rule filter_by_mapq:

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -276,6 +276,12 @@ rule demultiplex_stats:
             print(lines // 2, file=fo)
 
 
+def read_group_flags(wildcards, sep=" "):
+    return (f" --rg-id {wildcards.sample}_rep{wildcards.replicate}"
+            f" --rg{sep}SM:{wildcards.sample}"
+            f" --rg{sep}LB:{wildcards.sample}_rep{wildcards.replicate}")
+
+
 rule align_to_reference:
     threads:
         19  # One fewer than available to allow other jobs to run in parallel
@@ -296,6 +302,7 @@ rule align_to_reference:
         aligner = config.get("aligner", "bowtie2")
         if aligner == "bowtie2":
             bowtie_mode = config.get("bowtie2_mode", "fast")
+            group_flags = read_group_flags(wildcards)
             shell("bowtie2"
                   " --reorder"
                   " -p {threads}"
@@ -303,22 +310,19 @@ rule align_to_reference:
                   " -1 {input.r1}"
                   " -2 {input.r2}"
                   " --{bowtie_mode}"
-                  " --rg-id {wildcards.sample}_rep{wildcards.replicate}"
-                  " --rg SM:{wildcards.sample}"
-                  " --rg LB:{wildcards.sample}_rep{wildcards.replicate}"
+                  " {group_flags}"
                   " 2> {log}"
                   " "
                   "| samtools sort -@ {threads} -o {output.bam} -"
             )
         elif aligner == "strobealign":
+            group_flags = read_group_flags(wildcards, sep = "=")
             shell("strobealign"
                   " -t {threads}"
                   " {params.reference.fasta}"
                   " {input.r1}"
                   " {input.r2}"
-                  " --rg-id={wildcards.sample}_rep{wildcards.replicate}"
-                  " --rg=SM:{wildcards.sample}"
-                  " --rg=LB:{wildcards.sample}_rep{wildcards.replicate}"
+                  " {group_flags}"
                   " 2> {log}"
                   " "
                   "| samtools sort -@ {threads} -o {output.bam} -"

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -292,7 +292,6 @@ rule align_to_reference:
     # - --sensitive (instead of --fast) would be default
     # - write uncompressed BAM?
     # - filter unmapped reads directly? (samtools view -F 4 or bowtie2 --no-unal)
-    # - add RG header
     run:
         aligner = config.get("aligner", "bowtie2")
         if aligner == "bowtie2":
@@ -304,6 +303,9 @@ rule align_to_reference:
                   " -1 {input.r1}"
                   " -2 {input.r2}"
                   " --{bowtie_mode}"
+                  " --rg-id {wildcards.sample}_rep{wildcards.replicate}"
+                  " --rg SM:{wildcards.sample}"
+                  " --rg LB:{wildcards.sample}_rep{wildcards.replicate}"
                   " 2> {log}"
                   " "
                   "| samtools sort -@ {threads} -o {output.bam} -"
@@ -314,6 +316,9 @@ rule align_to_reference:
                   " {params.reference.fasta}"
                   " {input.r1}"
                   " {input.r2}"
+                  " --rg-id={wildcards.sample}_rep{wildcards.replicate}"
+                  " --rg=SM:{wildcards.sample}"
+                  " --rg=LB:{wildcards.sample}_rep{wildcards.replicate}"
                   " 2> {log}"
                   " "
                   "| samtools sort -@ {threads} -o {output.bam} -"

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -276,7 +276,7 @@ rule demultiplex_stats:
             print(lines // 2, file=fo)
 
 
-rule bowtie2:
+rule align_to_reference:
     threads:
         19  # One fewer than available to allow other jobs to run in parallel
     output:
@@ -285,7 +285,7 @@ rule bowtie2:
         r1="final/demultiplexed/{sample}_rep{replicate}_R1.fastq.gz",
         r2="final/demultiplexed/{sample}_rep{replicate}_R2.fastq.gz",
     params:
-        index=lambda wildcards: references[wildcards.reference].bowtie_index
+        reference=lambda wildcards: references[wildcards.reference]
     log:
         "log/4-mapped/{sample}_rep{replicate}.{reference}.log"
     # TODO
@@ -299,7 +299,7 @@ rule bowtie2:
             shell("bowtie2"
                   " --reorder"
                   " -p {threads}"
-                  " -x {params.index}"
+                  " -x {params.reference.bowtie_index}"
                   " -1 {input.r1}"
                   " -2 {input.r2}"
                   " --fast"
@@ -307,8 +307,18 @@ rule bowtie2:
                   " "
                   "| samtools sort -@ {threads} -o {output.bam} -"
             )
+        elif aligner == "strobealign":
+            shell("strobealign"
+                  " -t {threads}"
+                  " {params.reference.fasta}"
+                  " {input.r1}"
+                  " {input.r2}"
+                  " 2> {log}"
+                  " "
+                  "| samtools sort -@ {threads} -o {output.bam} -"
+            )
         else:
-            msg = f"Unknown aligner: {aligner}. Valid choices: bowtie2"
+            msg = f"Unknown aligner: {aligner}. Valid choices: bowtie2, strobealign"
             raise ValueError(msg)
 
 

--- a/src/minute/minute.yaml
+++ b/src/minute/minute.yaml
@@ -27,5 +27,5 @@ fragment_size: 150
 max_barcode_errors: 1
 
 # Aligner to use in the genome alignment step
-# Valid options: bowtie2
-aligner: "bowtie2"
+# Valid options: bowtie2, strobealign
+aligner: "strobealign"

--- a/src/minute/minute.yaml
+++ b/src/minute/minute.yaml
@@ -29,3 +29,7 @@ max_barcode_errors: 1
 # Aligner to use in the genome alignment step
 # Valid options: bowtie2, strobealign
 aligner: "strobealign"
+
+# Bowtie2 alignment mode:
+# fast, fast-local, sensitive, sensitive-local, very-sensitive
+bowtie2_mode: "fast"

--- a/src/minute/minute.yaml
+++ b/src/minute/minute.yaml
@@ -26,6 +26,14 @@ fragment_size: 150
 # Allow this many errors in the barcode when demultiplexing
 max_barcode_errors: 1
 
+# Filter out reads under certain mapping quality (0: no filtering)
+mapping_quality: 0
+
+# If filtered_bigwigs rule is run, additional bigWig files are produced,
+# where reads with MQ lower than this value are filtered out. This parameter
+# is independent of mapping_quality parameter above.
+mapping_quality_bigwig: 20
+
 # Aligner to use in the genome alignment step
 # Valid options: bowtie2, strobealign
 aligner: "strobealign"

--- a/src/minute/minute.yaml
+++ b/src/minute/minute.yaml
@@ -25,3 +25,7 @@ fragment_size: 150
 
 # Allow this many errors in the barcode when demultiplexing
 max_barcode_errors: 1
+
+# Aligner to use in the genome alignment step
+# Valid options: bowtie2
+aligner: "bowtie2"

--- a/src/minute/minute.yaml
+++ b/src/minute/minute.yaml
@@ -36,7 +36,7 @@ mapping_quality_bigwig: 20
 
 # Aligner to use in the genome alignment step
 # Valid options: bowtie2, strobealign
-aligner: "strobealign"
+aligner: "bowtie2"
 
 # Bowtie2 alignment mode:
 # fast, fast-local, sensitive, sensitive-local, very-sensitive

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -36,4 +36,8 @@ mapping_quality_bigwig: 20
 
 # Aligner to use in the genome alignment step
 # Valid options: bowtie2, strobealign
-aligner: "strobealign"
+aligner: "bowtie2"
+
+# Bowtie2 alignment mode:
+# fast, fast-local, sensitive, sensitive-local, very-sensitive
+bowtie2_mode: "fast-local"

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -35,5 +35,5 @@ mapping_quality: 0
 mapping_quality_bigwig: 20
 
 # Aligner to use in the genome alignment step
-# Valid options: bowtie2
-aligner: "bowtie2"
+# Valid options: bowtie2, strobealign
+aligner: "strobealign"

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -33,3 +33,7 @@ mapping_quality: 0
 # where reads with MQ lower than this value are filtered out. This parameter
 # is independent of mapping_quality parameter above.
 mapping_quality_bigwig: 20
+
+# Aligner to use in the genome alignment step
+# Valid options: bowtie2
+aligner: "bowtie2"

--- a/testdata/minute.yaml
+++ b/testdata/minute.yaml
@@ -40,4 +40,4 @@ aligner: "bowtie2"
 
 # Bowtie2 alignment mode:
 # fast, fast-local, sensitive, sensitive-local, very-sensitive
-bowtie2_mode: "fast-local"
+bowtie2_mode: "fast"


### PR DESCRIPTION
This PR includes broader custom alignment changes that supersede #188. 

A few config-related changes:

- Alignment to reference genome can optionally be set to `strobealign`. This provides a more flexible setup where we can better assess performance differences between aligners.
- `bowtie2` rule has been renamed to `align_to_reference` accordingly.
- Custom parameters `aligner` and `bowtie2_mode` have been added to `minute.yaml`. In the absence of those, the defaults are back to previous versions: bowtie2 on `--fast` mode.
- Previous config fields `mapping_quality` and `mapping_quality_bigwig` are added to the `minute.yaml` default template that is produced in `minute init`.
- Read group IDs (`@RG` header and `RG:` tag in individual alignments) are added to the BAM outputs.
- `environment.yml` changed accordingly to include `strobealign` dependency.

