### PR TITLE
Improve CLI user experience

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # minute Changelog
 
+## v0.9.2
+
+### Minor
+* More thorough check of user input, including: validating minute.yaml
+has required fields, reference files exist, FASTQ files match libraries.tsv,
+bowtie2 index is not required if aligner strobealign is used.
+* More verbose command line messages when an error occurs.
+
 ## v0.9.1
 
 ### Features

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 has required fields, reference files exist, FASTQ files match libraries.tsv,
 bowtie2 index is not required if aligner strobealign is used.
 * More verbose command line messages when an error occurs.
+* More verbose docstring for `minute run` command.
 
 ## v0.9.1
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.9.1"
+version = "0.9.2"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -51,7 +51,7 @@ localrules:
     insert_size_metrics,
 
 
-references = make_references(config["references"])
+references = make_references(config["references"], config.get("aligner", "bowtie2"))
 libraries = list(read_libraries("libraries.tsv"))
 multiplexed_libraries = [lib for lib in libraries if isinstance(lib, MultiplexedReplicate)]
 direct_libraries = [lib for lib in libraries if not isinstance(lib, MultiplexedReplicate)]

--- a/src/minute/__init__.py
+++ b/src/minute/__init__.py
@@ -179,15 +179,17 @@ def get_maplib_by_name(maplibs: Iterable[LibraryWithReference], name: str) -> Li
         if m.library.name == name:
             return m
 
-def make_references(config) -> Dict[str, Reference]:
+def make_references(config, aligner) -> Dict[str, Reference]:
     references = dict()
     for name, ref in config.items():
         fasta = Path(ref["fasta"])
         exclude_bed = Path(ref["exclude"]) if ref["exclude"] else None
-        try:
-            bowtie_index = detect_bowtie_index_name(ref["fasta"])
-        except FileNotFoundError as e:
-            sys.exit(str(e))
+        bowtie_index = None
+        if aligner == "bowtie2":
+            try:
+                bowtie_index = detect_bowtie_index_name(ref["fasta"])
+            except FileNotFoundError as e:
+                sys.exit(str(e))
         references[name] = Reference(
             name=name,
             fasta=fasta,

--- a/src/minute/__init__.py
+++ b/src/minute/__init__.py
@@ -183,6 +183,8 @@ def make_references(config, aligner) -> Dict[str, Reference]:
     references = dict()
     for name, ref in config.items():
         fasta = Path(ref["fasta"])
+        if not fasta.exists():
+            sys.exit(f"Reference file {fasta} not found.")
         exclude_bed = Path(ref["exclude"]) if ref["exclude"] else None
         bowtie_index = None
         if aligner == "bowtie2":

--- a/src/minute/__main__.py
+++ b/src/minute/__main__.py
@@ -6,7 +6,7 @@ import ast
 import logging
 import pkgutil
 import sys
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 import importlib.resources
 
@@ -28,7 +28,7 @@ def main(arguments=None):
 #    parser.add_argument("--version", action="version", version=__version__)
     subparsers = parser.add_subparsers()
     subparser = subparsers.add_parser(
-        subcommand_name, help=module.__doc__.split("\n")[1], description=module.__doc__
+        subcommand_name, help=module.__doc__.split("\n")[1], description=module.__doc__, formatter_class=RawDescriptionHelpFormatter
     )
     module.add_arguments(subparser)
     args, remainder = parser.parse_known_args(arguments)

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -61,7 +61,10 @@ def run_snakemake(
         libraries = list(read_libraries("libraries.tsv"))
         scaling_groups = list(read_scaling_groups("groups.tsv", libraries))
     except FileNotFoundError as e:
-        sys.exit(e)
+        sys.exit(
+            f"Samples configuration file '{e.filename}' not found. "
+            f"Please see the documentation for how to create it."
+        )
 
     with importlib.resources.path("minute", "Snakefile") as snakefile:
         command = [

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml import scanner
 
-from .. import libraries_unused_in_groups, read_libraries, read_scaling_groups
+from .. import libraries_unused_in_groups, read_libraries, read_scaling_groups, make_references
 
 logger = logging.getLogger(__name__)
 
@@ -112,6 +112,14 @@ def validate_config_file(yaml):
             f"Present: {yaml_fields}"
         )
 
+    for name, ref in config["references"].items():
+        fasta = Path(ref["fasta"])
+        if not fasta.exists():
+            sys.exit(
+                f"Reference file {fasta} for genome {name} not found."
+            )
+
+    make_references(config["references"], config.get("aligner", "bowtie2"))
 
 def warn_about_unused_libraries(libraries, scaling_groups, limit=4):
     """

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -111,14 +111,6 @@ def validate_config_file(yaml, required):
             f"documentation for reference. "
         )
     check_required_fields_exist(yaml, required)
-
-    for name, ref in config["references"].items():
-        fasta = Path(ref["fasta"])
-        if not fasta.exists():
-            sys.exit(
-                f"Reference file {fasta} for genome {name} not found."
-            )
-
     make_references(config["references"], config.get("aligner", "bowtie2"))
 
 def check_required_fields_exist(yaml, required):

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -79,10 +79,11 @@ def run_snakemake(
 
 def validate_config_file(yaml):
     """
-    Checks that the configuration minute.yaml file exists and has valid structure
+    Checks that the configuration minute.yaml file exists and has valid
+    structure and field values.
     """
     try:
-        _ = YAML(typ="safe").load(yaml)
+        config = YAML(typ="safe").load(yaml)
     except FileNotFoundError as e:
         sys.exit(
             f"Pipeline configuration file '{e.filename}' not found. "
@@ -95,6 +96,20 @@ def validate_config_file(yaml):
             f"{e}"
             f"\n\nCheck example minute.yaml file on the "
             f"documentation for reference. "
+        )
+
+    required = set([
+        "references",
+        "umi_length",
+        "fragment_size",
+        "max_barcode_errors",
+    ])
+    yaml_fields = set(config.keys())
+    if not required.issubset(yaml_fields):
+        sys.exit(
+            f"Missing required fields in {yaml} configuration file.\n"
+            f"Missing: {required.difference(yaml_fields)}.\n"
+            f"Present: {yaml_fields}"
         )
 
 

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from ruamel.yaml import YAML
 from ruamel.yaml import scanner
 
-from .. import libraries_unused_in_groups, read_libraries, read_scaling_groups, make_references
+from .. import libraries_unused_in_groups, read_libraries, read_scaling_groups, make_references, ParseError
 
 logger = logging.getLogger(__name__)
 
@@ -69,6 +69,8 @@ def run_snakemake(
             f"Samples configuration file '{e.filename}' not found. "
             f"Please see the documentation for how to create it."
         )
+    except ParseError as e:
+        sys.exit(f"Error parsing config files: {e}")
 
     check_fastq_basenames_exist(libraries)
     with importlib.resources.path("minute", "Snakefile") as snakefile:

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -17,6 +17,7 @@ import subprocess
 import sys
 from pathlib import Path
 from ruamel.yaml import YAML
+from ruamel.yaml import scanner
 
 from .. import libraries_unused_in_groups, read_libraries, read_scaling_groups
 
@@ -78,7 +79,7 @@ def run_snakemake(
 
 def validate_config_file(yaml):
     """
-    Checks that the configuration minute.yaml file exists
+    Checks that the configuration minute.yaml file exists and has valid structure
     """
     try:
         _ = YAML(typ="safe").load(yaml)
@@ -86,6 +87,14 @@ def validate_config_file(yaml):
         sys.exit(
             f"Pipeline configuration file '{e.filename}' not found. "
             f"Please see the documentation for how to create it."
+        )
+    except scanner.ScannerError as e:
+        sys.exit(
+            f"Pipeline configuration file '{yaml}' not correctly formed. "
+            f"See error below.\n\n"
+            f"{e}"
+            f"\n\nCheck example minute.yaml file on the "
+            f"documentation for reference. "
         )
 
 

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -50,13 +50,8 @@ def run_snakemake(
     cores=None,
     arguments=None,
 ):
-    try:
-        _ = YAML(typ="safe").load(Path("minute.yaml"))
-    except FileNotFoundError as e:
-        sys.exit(
-            f"Pipeline configuration file '{e.filename}' not found. "
-            f"Please see the documentation for how to create it."
-        )
+    validate_config_file(Path("minute.yaml"))
+
     try:
         libraries = list(read_libraries("libraries.tsv"))
         scaling_groups = list(read_scaling_groups("groups.tsv", libraries))
@@ -79,6 +74,19 @@ def run_snakemake(
 
     warn_about_unused_libraries(libraries, scaling_groups)
     sys.exit(exit_code)
+
+
+def validate_config_file(yaml):
+    """
+    Checks that the configuration minute.yaml file exists
+    """
+    try:
+        _ = YAML(typ="safe").load(yaml)
+    except FileNotFoundError as e:
+        sys.exit(
+            f"Pipeline configuration file '{e.filename}' not found. "
+            f"Please see the documentation for how to create it."
+        )
 
 
 def warn_about_unused_libraries(libraries, scaling_groups, limit=4):


### PR DESCRIPTION
Many small changes on the CLI that validate more thoroughly the user input, catch some exceptions and print better messages overall.

The idea is to communicate better with the user when something in the configuration is not correct:

1. Required parameter that have no built-in defaults are checked up front on the minute.yaml config file and an appropriate message is printed if any of them is missing.
2. Parsing exceptions caught allowing for a cleaner exit, both YAML and .tsv column numbers.
3. Bowtie2 reference indexes only required if bowtie2 is used.
4. `make_references` now checks that the reference file exists before looking for an index. This is only for the user to better understand the error.
5. Check that Fastq files match the libraries.tsv file.
6. A later addition: fix CLI help formatting for the main command `minute run --help` (the default argparse formatter was eating all the endlines) and add the relevant final target rules that the user can specify on the docstring. I wanted this to be a validation step as well, but the target rule is not preemptively validated because it can be difficult to distinguish that from other additional snakemake parameters, and `subprocess.call` prevents from catching the `MissingRuleException` from snakemake.