### PR TITLE
New rule to skip the scaling

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # minute Changelog
 
+## v0.10.0
+
+### Features
+
+* New target rule `no_scaling` to skip the scaling process completely and
+produce only the unscaled bigWig files and a final MultiQC report with
+non-scaling related QC metrics.
+
 ## v0.9.2
 
 ### Minor

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -77,5 +77,14 @@ still produces full scaling information and MultiQC report, and it is very quick
 to run.
 
 **`mapq_bigwigs`**. Produces extra bigWigs `mapq.bw` filtered by mapping quality.
+This requires a `mapping_quality_bigwig` parameter value higher than zero in the
+`minute.yaml` configuration.
 
 **`pooled_only`**. Produces only the bigWigs for the pooled replicates.
+
+**`no_bigwigs`**. Runs the default pipeline but skips the bigWig generation
+entirely. This is useful for a quick check on QC metrics, since the rest of the
+steps are significantly faster than bigWig generation.
+
+**`no_scaling`**. Skips entirely the scaling statistics and bigWigs. Produces
+only unscaled bigWigs and a MultiQC report with only non-scaling QC metrics.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.9.2"
+version = "0.10.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -61,15 +61,10 @@ maplibs = list(flatten_scaling_groups(scaling_groups))
 if not is_snakemake_calling_itself():
     print(format_metadata_overview(references, libraries, maplibs, scaling_groups), file=sys.stderr)
 
-multiqc_inputs = (
+multiqc_unscaled_inputs = (
     [
-        "reports/scalinginfo.txt",
         "reports/stats_summary.txt",
-        "reports/pooled_stats_summary.txt",
-        "reports/scaling_barplot.png",
-        "reports/grouped_scaling_barplot.png",
-        "reports/barcode_representation.png",
-        "reports/barcode_representation_perc.png"
+        "reports/pooled_stats_summary.txt"
     ]
     + expand("reports/fastqc/{library.fastqbase}_R{read}_fastqc/fastqc_data.txt", library=multiplexed_libraries, read=(1, 2))
     + expand("log/2-noadapters/{library.fastqbase}.trimmed.log", library=multiplexed_libraries)
@@ -78,8 +73,21 @@ multiqc_inputs = (
     + expand("stats/final/{maplib.name}.insertsizes.txt", maplib=get_all_replicates(maplibs))
     + expand("stats/final/{maplib.name}.idxstats.txt", maplib=[m for m in maplibs])
 )
+
+multiqc_inputs = (
+    multiqc_unscaled_inputs
+    + [
+        "reports/scalinginfo.txt",
+        "reports/scaling_barplot.png",
+        "reports/grouped_scaling_barplot.png",
+        "reports/barcode_representation.png",
+        "reports/barcode_representation_perc.png"
+    ]
+)
+
+unscaled_bigwigs = expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=maplibs)
 bigwigs = (
-    expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=maplibs)
+    unscaled_bigwigs
     + expand("final/bigwig/{maplib.name}.scaled.bw",
         maplib=flatten_scaling_groups(scaling_groups, controls=False))
 )
@@ -130,6 +138,12 @@ rule no_bigwigs:
         "reports/multiqc_report.html",
 
 
+rule no_scaling:
+    input:
+        unscaled_bigwigs,
+        "reports/multiqc_report_unscaled.html"
+
+
 rule multiqc_full:
     output: "reports/multiqc_report_full.html"
     input:
@@ -154,6 +168,19 @@ rule multiqc:
         "log/multiqc_report.log"
     shell:
         "multiqc -f -o reports/ -c {input.multiqc_config} {input} 'stats/final' 2> {log}"
+
+
+rule multiqc_no_scaling:
+    output: "reports/multiqc_report_unscaled.html"
+    input:
+        multiqc_unscaled_inputs,
+        multiqc_config=os.path.join(os.path.dirname(workflow.snakefile), "multiqc_config.yaml")
+    log:
+        "log/multiqc_report_unscaled.log"
+    shell:
+        "multiqc -f -o reports/ -c {input.multiqc_config} {input} 'stats/final' 2> {log}"
+        " && "
+        " mv reports/multiqc_report.html {output}"
 
 
 rule clean:

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -35,6 +35,10 @@ Alternative target rules:
                     since the rest of the steps are significantly faster than
                     bigWig generation.
 
+    no_scaling      Skips entirely the scaling statistics and bigWigs. Produces
+                    only unscaled bigWigs and a MultiQC report with only
+                    non-scaling QC metrics.
+
 See minute documentation for a more detailed description of the available target
 rules and their outputs.
 


### PR DESCRIPTION
A small addition to the set of final rules called `no_scaling`. The purpose of this is to obtain only mapping metrics and other non-scaling-dependent QC metrics on a MultiQC report, and skip the scaling step and the subsequent generation of `scaled.bw` bigwig files.