### PR TITLE
Handle NA insert sizes in extract_fragment_size rule

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,16 @@
 # minute Changelog
 
+## v0.10.1
+
+### Bug fixes
+
+* Fix edge-case exception when trying to convert NA value to int after parsing
+an empty insert size metrics file.
+
+### Other
+
+* Prioritize reporting rules over bigWig generation rules.
+
 ## v0.10.0
 
 ### Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -145,6 +145,7 @@ rule no_scaling:
 
 
 rule multiqc_full:
+    priority: 10
     output: "reports/multiqc_report_full.html"
     input:
         multiqc_inputs,
@@ -160,6 +161,7 @@ rule multiqc_full:
 
 
 rule multiqc:
+    priority: 10
     output: "reports/multiqc_report.html"
     input:
         multiqc_inputs,
@@ -171,6 +173,7 @@ rule multiqc:
 
 
 rule multiqc_no_scaling:
+    priority: 10
     output: "reports/multiqc_report_unscaled.html"
     input:
         multiqc_unscaled_inputs,
@@ -584,6 +587,7 @@ for group in scaling_groups:
 
 
 rule summarize_scaling_factors:
+    priority: 10
     output:
         info="reports/scalinginfo.txt"
     input:
@@ -598,6 +602,7 @@ rule summarize_scaling_factors:
 
 
 rule summary_scaled_barplots:
+    priority: 10
     output:
         plot=expand("reports/scaling_barplot.{ext}", ext=["png", "pdf"]),
         grouped_plot=expand("reports/grouped_scaling_barplot.{ext}", ext=["png", "pdf"]),
@@ -768,6 +773,7 @@ rule pooled_stats:
 
 
 rule replicate_stats_summary:
+    priority: 10
     output:
         txt="reports/stats_summary.txt"
     input:
@@ -798,6 +804,7 @@ rule replicate_stats_summary:
 
 
 rule pooled_stats_summary:
+    priority: 10
     output:
         txt="reports/pooled_stats_summary.txt"
     input:

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -621,8 +621,18 @@ rule extract_fragment_size:
             except StopIteration:
                 is_metrics = dict()
 
-            print(int(is_metrics.get("median_insert_size", "NA")),
-                  file=f)
+            median_size = is_metrics.get("median_insert_size", "NA")
+            # bamCoverage needs an --int value for --extendReads
+            try:
+                median_size = int(median_size)
+            except ValueError:
+                print(
+                    f"Median insert size not numerical. Resorting to config "
+                    f"fragment size {config['fragment_size']} for bigWig "
+                    f"generation."
+                )
+                median_size = int(config["fragment_size"])
+            print(median_size, file=f)
 
 
 rule scaled_bigwig:


### PR DESCRIPTION
A hotfix for an issue that arises when absolutely nothing comes out of a barcode, and trying to convert `NA` value to integer in `extract_fragment_size` rule.
Somehow in previous #191 Picard was still getting an insert size out of very few reads so this edge case was not being properly tested. In some cases it might be useful to still try to produce the bigWig files, so configuration `fragment_size` is used when a `NA` is found.

Related to this, I added priority for all the rules that calculate values for reports and the MultiQC reports. The rationale behind this is that it is OK if the pipeline fails because some sample had no reads, and hence it is not possible to produce the bigWig file, but in order to troubleshoot or understand what happens, MultiQC results are valuable, so we want the MultiQC report to be a preferred rule when possible, to save the user a `minute run --keep-going` in as many cases as possible.