### PR TITLE
New rules for generating subsets of bigWig files

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,15 @@
 # minute Changelog
 
+## v0.11.0
+
+### Features
+
+* Introduced pooled_only_minimal rule that generates only scaled replicate pool
+for treatments, and unscaled replicate pools for controls in the groups.tsv
+file.
+* Rule quick now produces the equivalent minimal set of bigWig (independent 
+replicate files: scaled for treatment, unscaled for controls).
+
 ## v0.10.1
 
 ### Bug fixes

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -72,6 +72,10 @@ Alternative to this are:
 
 **`full`**. Includes computationally costly extra QC: deepTools fingerprint.
 
+**`quick`**. Runs the default pipeline but reduces the amount of bigWig files
+produced. Only scaled bigWig files will be generated for treatments, and
+unscaled bigWig files will be generated for controls.
+
 **`no_bigwigs`**. Runs demultiplexing and alignment, but no bigWig generation. This
 still produces full scaling information and MultiQC report, and it is very quick
 to run.
@@ -81,6 +85,10 @@ This requires a `mapping_quality_bigwig` parameter value higher than zero in the
 `minute.yaml` configuration.
 
 **`pooled_only`**. Produces only the bigWigs for the pooled replicates.
+
+**`pooled_only_minimal`**. Runs the default pipeline, but it only generates
+bigWig files for the pools present in groups.tsv, scaled for treatment libraries
+and unscaled for the controls.
 
 **`no_bigwigs`**. Runs the default pipeline but skips the bigWig generation
 entirely. This is useful for a quick check on QC metrics, since the rest of the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -58,6 +58,7 @@ multiplexed_libraries = [lib for lib in libraries if isinstance(lib, Multiplexed
 direct_libraries = [lib for lib in libraries if not isinstance(lib, MultiplexedReplicate)]
 scaling_groups = list(read_scaling_groups("groups.tsv", libraries))
 maplibs = list(flatten_scaling_groups(scaling_groups))
+treatments = list(flatten_scaling_groups(scaling_groups, controls = False))
 controls = list(get_all_controls(scaling_groups))
 
 
@@ -91,23 +92,19 @@ multiqc_inputs = (
 unscaled_bigwigs = expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=maplibs)
 bigwigs = (
     unscaled_bigwigs
-    + expand("final/bigwig/{maplib.name}.scaled.bw",
-        maplib=flatten_scaling_groups(scaling_groups, controls=False))
+    + expand("final/bigwig/{maplib.name}.scaled.bw", maplib=treatments)
 )
 mapping_quality_bigwigs = (
     expand("final/bigwig/{maplib.name}.unscaled.mapq.bw", maplib=maplibs)
-    + expand("final/bigwig/{maplib.name}.scaled.mapq.bw",
-        maplib=flatten_scaling_groups(scaling_groups, controls=False))
+    + expand("final/bigwig/{maplib.name}.scaled.mapq.bw", maplib=treatments)
 )
 pool_bigwigs = (
     expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=get_all_pools(maplibs))
-    + expand("final/bigwig/{maplib.name}.scaled.bw",
-        maplib=get_all_pools(flatten_scaling_groups(scaling_groups, controls=False)))
+    + expand("final/bigwig/{maplib.name}.scaled.bw", maplib=get_all_pools(treatments))
 )
 pool_bigwigs_minimal = (
     expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=get_all_pools(controls))
-    + expand("final/bigwig/{maplib.name}.scaled.bw",
-        maplib=get_all_pools(flatten_scaling_groups(scaling_groups, controls=False)))
+    + expand("final/bigwig/{maplib.name}.scaled.bw", maplib=get_all_pools(treatments))
 )
 
 rule final:

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -18,6 +18,7 @@ from minute import (
     map_fastq_prefix_to_list_of_libraries,
     make_references,
     flatten_scaling_groups,
+    get_all_controls,
     get_all_pools,
     get_all_replicates,
     get_maplib_by_name,
@@ -57,6 +58,8 @@ multiplexed_libraries = [lib for lib in libraries if isinstance(lib, Multiplexed
 direct_libraries = [lib for lib in libraries if not isinstance(lib, MultiplexedReplicate)]
 scaling_groups = list(read_scaling_groups("groups.tsv", libraries))
 maplibs = list(flatten_scaling_groups(scaling_groups))
+controls = list(get_all_controls(scaling_groups))
+
 
 if not is_snakemake_calling_itself():
     print(format_metadata_overview(references, libraries, maplibs, scaling_groups), file=sys.stderr)
@@ -101,6 +104,11 @@ pool_bigwigs = (
     + expand("final/bigwig/{maplib.name}.scaled.bw",
         maplib=get_all_pools(flatten_scaling_groups(scaling_groups, controls=False)))
 )
+pool_bigwigs_minimal = (
+    expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=get_all_pools(controls))
+    + expand("final/bigwig/{maplib.name}.scaled.bw",
+        maplib=get_all_pools(flatten_scaling_groups(scaling_groups, controls=False)))
+)
 
 rule final:
     input:
@@ -123,6 +131,12 @@ rule full:
 rule pooled_only:
     input:
         pool_bigwigs,
+        "reports/multiqc_report.html"
+
+
+rule pooled_only_minimal:
+    input:
+        pool_bigwigs_minimal,
         "reports/multiqc_report.html"
 
 

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -90,6 +90,10 @@ multiqc_inputs = (
 )
 
 unscaled_bigwigs = expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=maplibs)
+bigwigs_minimal = (
+    expand("final/bigwig/{maplib.name}.unscaled.bw", maplib=controls)
+    + expand("final/bigwig/{maplib.name}.scaled.bw", maplib=treatments)
+)
 bigwigs = (
     unscaled_bigwigs
     + expand("final/bigwig/{maplib.name}.scaled.bw", maplib=treatments)
@@ -115,7 +119,7 @@ rule final:
 
 rule quick:
     input:
-        bigwigs,
+        bigwigs_minimal,
         "reports/multiqc_report.html",
 
 

--- a/src/minute/__init__.py
+++ b/src/minute/__init__.py
@@ -167,6 +167,16 @@ def flatten_scaling_groups(groups: Iterable[ScalingGroup], controls: bool = True
                     yield maplib
 
 
+def get_all_controls(groups: Iterable[ScalingGroup]) -> Iterable[LibraryWithReference]:
+    seen = set()
+    maplibs = list()
+    for group in groups:
+        for pair in group.normalization_pairs:
+            if pair.control.name not in seen:
+                seen.add(pair.control.name)
+                yield pair.control
+
+
 def get_all_pools(maplibs: Iterable[LibraryWithReference]) -> List[LibraryWithReference]:
     return [m for m in maplibs if isinstance(m.library, Pool)]
 

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -25,6 +25,10 @@ Alternative target rules:
     pooled_only     Runs the default pipeline, but only generates the bigWig
                     files corresponding to the pooled replicates.
 
+    pooled_only_minimal Runs the default pipeline, but it only generates bigWig
+                    files for the pools present in groups.tsv, scaled for
+                    treatment libraries and unscaled for the controls.
+
     mapq_bigwigs    Generates an additional set of bigWig files where each final
                     BAM alignment is also filtered for mapping quality. This
                     requires a mapping_quality_bigwig parameter value higher

--- a/src/minute/cli/run.py
+++ b/src/minute/cli/run.py
@@ -22,6 +22,11 @@ Alternative target rules:
                     is a computationally expensive step that can significantly
                     increase runtime on highly multiplexed minute runs.
 
+    quick           Runs the default pipeline but reduces the amount of bigWig
+                    files produced. Only scaled bigWig files will be generated
+                    for treatments, and unscaled bigWig files will be generated
+                    for controls.
+
     pooled_only     Runs the default pipeline, but only generates the bigWig
                     files corresponding to the pooled replicates.
 


### PR DESCRIPTION
This PR adds ways to reduce the amount of bigWig files generated to the minimal set of meaningful ones. The idea is that most of the time we don't need to produce both scaled and unscaled files, so now there are rules to produce scaled treatments and unscaled (RPGC-scaled) controls, generally halving the amount of bigWig files generated. More specifically:

* `quick`: This rule existed previously, as opposed to `full` which also runs the fingerprints, but now it also includes only the minimal set of bigwigs. It is not currently the default, although I am considering making it the default `final` rule.
* `pooled_only_minimal`: Pooled replicates in groups.tsv but only scaled for treatments and unscaled for controls.

I have also included a `get_all_controls` function and now `treatments` and `controls` exist as global variables for legibility of these sets.