### PR TITLE
Conda environment update

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,12 @@
 # minute Changelog
 
+## v0.11.1
+
+### Other
+
+* Conda environment specification updated to point to more recent versions of
+bowtie2, MultiQC, and cutadapt.
+
 ## v0.11.0
 
 ### Features

--- a/environment.yml
+++ b/environment.yml
@@ -8,22 +8,16 @@ dependencies:
   # - importlib-metadata   # [py<38]
   - ruamel.yaml
   - snakemake-minimal >= 7.22.0
-  # Explicit openjdk dependency should not be needed - remove when Picard is bumped to 3.0.1 or later
-  - openjdk >= 17.0.0
   - samtools >=1.13
-  - cutadapt >=3.7
-  # bowtie2 2.5.2 crashes on the tests
-  - bowtie2 =2.5.1
+  - cutadapt >=5.1
+  - bowtie2 >=2.5.4
   - strobealign >= 0.13.0
   - je-suite >=2.0.RC
-  - igvtools >=2.5.3
   - deeptools >=3.5.0
-  - picard >=2.26.0
+  - picard >=3.4.0
   - fastqc >=0.11.9
   - bedtools >=2.30.0
-  # 'output_fn_name' configuration setting is broken in multiqc 1.18 and 1.19
-  # multiqc 1.20 conflicts with pysam
-  - multiqc =1.17
+  - multiqc >1.20
   - xopen >=1.2.0
   - sra-tools >=2.11.0
   - r-base >=4.0.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
     "ruamel.yaml",
     "xopen",


### PR DESCRIPTION
This PR intends to make a more up-to-date environment for `minute`. More specifically:

- cutadapt >= 5.1 for better handling of ambiguous reads.
- bowtie2 bug on 2.5.2 that crashed on empty R2 has been fixed in more recent versions.
- picard newer versions (>=3.0.1) elliminate the need for explicit openjdk dependency.
- multiqc more recent versions have fixed the output name of the report and also not conflicting anymore with pysam.
- igvtools was a stale dependency and has been removed too.