### PR TITLE
Improvements in the reports

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,18 @@
 # minute Changelog
 
+## v0.12.0
+
+### Features
+
+* Scaling info now contains scaled calculated values that are shown in the 
+summary bar plots.
+
+### Bug fixes
+
+* Summary plots scale better on highly demultiplexed runs.
+* Barplots show bars in the case where there is only one replicate per condition.
+
+
 ## v0.11.1
 
 ### Other

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
     "ruamel.yaml",
     "xopen",

--- a/src/minute/Snakefile
+++ b/src/minute/Snakefile
@@ -604,7 +604,7 @@ for group in scaling_groups:
 rule summarize_scaling_factors:
     priority: 10
     output:
-        info="reports/scalinginfo.txt"
+        info=temp("reports/scalinginfo_raw.txt")
     input:
         factors=["stats/8-scalinginfo/{scaling_group_name}.txt".format(scaling_group_name=group.name) for group in scaling_groups]
     run:
@@ -622,9 +622,10 @@ rule summary_scaled_barplots:
         plot=expand("reports/scaling_barplot.{ext}", ext=["png", "pdf"]),
         grouped_plot=expand("reports/grouped_scaling_barplot.{ext}", ext=["png", "pdf"]),
         barcode_plot=expand("reports/barcode_representation.{ext}", ext=["png", "pdf"]),
-        barcode_plot_perc=expand("reports/barcode_representation_perc.{ext}", ext=["png", "pdf"])
+        barcode_plot_perc=expand("reports/barcode_representation_perc.{ext}", ext=["png", "pdf"]),
+        info_updated="reports/scalinginfo.txt"
     input:
-        info="reports/scalinginfo.txt"
+        info="reports/scalinginfo_raw.txt"
     script:
         "summary_plots.R"
 

--- a/src/minute/summary_plots.R
+++ b/src/minute/summary_plots.R
@@ -208,17 +208,25 @@ get_scaling_groups_number <- function(scaling_df) {
   length(levels(as.factor(scaling_df$scaling_group)))
 }
 
+get_conditions_number <- function(scaling_df) {
+  length(levels(as.factor(scaling_df$condition)))
+}
+
 scalinginfo <- snakemake@input[[1]]
 scaling_df <- read.table(scalinginfo, sep="\t", header = T, comment.char = "")
 ngroups <- get_scaling_groups_number(scaling_df)
+nconditions <- get_conditions_number(calculate_ratios_and_groups(scaling_df))
 
-single_width <- 5
+single_width <- max(4, 0.75 * nconditions)
 
 # Account for longer names
 single_height <- 9
 
 panel_width <- single_width * 2
 panel_height <- ceiling(ngroups / 2) * single_height
+
+bc_rep_height <- max(8, ngroups + (nconditions / 4))
+bc_rep_width <- max(12, 0.75 * nconditions)
 
 ggsave(snakemake@output[[1]],
        plot = minute_scaled_replicates_barplot(scaling_df),
@@ -250,31 +258,31 @@ ggsave(snakemake@output[[4]],
 
 ggsave(snakemake@output[[5]],
        plot = barcode_representation_barplot(scaling_df),
-       width = 12,
-       height = 7,
+       width = bc_rep_width,
+       height = bc_rep_height,
        dpi = 150,
        units = "cm",
        bg = "white")
 
 ggsave(snakemake@output[[6]],
        plot = barcode_representation_barplot(scaling_df),
-       width = 12,
-       height = 7,
+       width = bc_rep_width,
+       height = bc_rep_height,
        dpi = 300,
        units = "cm")
 
 ggsave(snakemake@output[[7]],
        plot = barcode_representation_barplot(scaling_df, percent = TRUE),
-       width = 12,
-       height = 7,
+       width = bc_rep_width,
+       height = bc_rep_height,
        dpi = 150,
        units = "cm",
        bg = "white")
 
 ggsave(snakemake@output[[8]],
        plot = barcode_representation_barplot(scaling_df, percent = TRUE),
-       width = 12,
-       height = 7,
+       width = bc_rep_width,
+       height = bc_rep_height,
        dpi = 300,
        units = "cm")
 

--- a/src/minute/summary_plots.R
+++ b/src/minute/summary_plots.R
@@ -10,8 +10,7 @@ suppressMessages(library(dplyr))
 #' @param scaling_file scalinginfo.txt out of the minute pipeline
 #'
 #' @return A ggplot
-minute_scaled_grouped_barplot <- function(scaling_file) {
-  scaling <- read.table(scaling_file, sep="\t", header = T, comment.char = "")
+minute_scaled_grouped_barplot <- function(scaling) {
   scaling <- calculate_ratios_and_groups(scaling)
   
   ggplot(data = scaling) + 
@@ -32,8 +31,7 @@ minute_scaled_grouped_barplot <- function(scaling_file) {
 #' @param scaling_file scalinginfo.txt out of the minute pipeline
 #'
 #' @return A ggplot
-minute_scaled_replicates_barplot <- function(scaling_file) {
-  scaling <- read.table(scaling_file, sep="\t", header = T, comment.char = "")
+minute_scaled_replicates_barplot <- function(scaling) {
   scaling <- calculate_ratios_and_groups(scaling)
   ggplot(data = scaling) + 
     aes(x = replace_delims_with_spaces(rep_grp), y = msr, fill = as.factor(rep_number)) +
@@ -57,8 +55,7 @@ minute_scaled_replicates_barplot <- function(scaling_file) {
 #' @param scaling_file scalinginfo.txt out of the minute pipeline
 #'
 #' @return A ggplot showing barcode representation
-barcode_representation_barplot <- function(scaling_file, percent = FALSE) {
-  scaling <- read.table(scaling_file, sep="\t", header = T, comment.char = "")
+barcode_representation_barplot <- function(scaling, percent = FALSE) {
   scaling <- calculate_ratios_and_groups(scaling)
 
   df_input <- scaling %>%
@@ -207,13 +204,13 @@ stacked_replicate_groups_plot <- function(df_combined, value_column) {
 #' Calculate number of groups in a scalinginfo.txt file
 #' 
 #' @param scaling_file Path to scalinginfo.txt file
-get_scaling_groups_number <- function(scaling_file) {
-  scaling <- read.table(scaling_file, sep="\t", header = T, comment.char = "")
-  length(levels(as.factor(scaling$scaling_group)))
+get_scaling_groups_number <- function(scaling_df) {
+  length(levels(as.factor(scaling_df$scaling_group)))
 }
 
 scalinginfo <- snakemake@input[[1]]
-ngroups <- get_scaling_groups_number(scalinginfo)
+scaling_df <- read.table(scalinginfo, sep="\t", header = T, comment.char = "")
+ngroups <- get_scaling_groups_number(scaling_df)
 
 single_width <- 5
 
@@ -224,35 +221,35 @@ panel_width <- single_width * 2
 panel_height <- ceiling(ngroups / 2) * single_height
 
 ggsave(snakemake@output[[1]],
-       plot = minute_scaled_replicates_barplot(scalinginfo),
+       plot = minute_scaled_replicates_barplot(scaling_df),
        width = panel_width,
        height = panel_height,
        dpi = 150,
        units = "cm")
 
 ggsave(snakemake@output[[2]],
-       plot = minute_scaled_replicates_barplot(scalinginfo),
+       plot = minute_scaled_replicates_barplot(scaling_df),
        width = panel_width,
        height = panel_height,
        dpi = 300,
        units = "cm")
 
 ggsave(snakemake@output[[3]],
-       plot = minute_scaled_grouped_barplot(scalinginfo),
+       plot = minute_scaled_grouped_barplot(scaling_df),
        width = panel_width,
        height = panel_height,
        dpi = 150,
        units = "cm")
 
 ggsave(snakemake@output[[4]],
-       plot = minute_scaled_grouped_barplot(scalinginfo),
+       plot = minute_scaled_grouped_barplot(scaling_df),
        width = panel_width,
        height = panel_height,
        dpi = 300,
        units = "cm")
 
 ggsave(snakemake@output[[5]],
-       plot = barcode_representation_barplot(scalinginfo),
+       plot = barcode_representation_barplot(scaling_df),
        width = 12,
        height = 7,
        dpi = 150,
@@ -260,14 +257,14 @@ ggsave(snakemake@output[[5]],
        bg = "white")
 
 ggsave(snakemake@output[[6]],
-       plot = barcode_representation_barplot(scalinginfo),
+       plot = barcode_representation_barplot(scaling_df),
        width = 12,
        height = 7,
        dpi = 300,
        units = "cm")
 
 ggsave(snakemake@output[[7]],
-       plot = barcode_representation_barplot(scalinginfo, percent = TRUE),
+       plot = barcode_representation_barplot(scaling_df, percent = TRUE),
        width = 12,
        height = 7,
        dpi = 150,
@@ -275,12 +272,15 @@ ggsave(snakemake@output[[7]],
        bg = "white")
 
 ggsave(snakemake@output[[8]],
-       plot = barcode_representation_barplot(scalinginfo, percent = TRUE),
+       plot = barcode_representation_barplot(scaling_df, percent = TRUE),
        width = 12,
        height = 7,
        dpi = 300,
        units = "cm")
 
 write.table(
-  calculate_ratios_and_groups(read.table(scalinginfo, sep="\t", header = TRUE, comment.char = "")),
-  file = snakemake@output[[9]], sep = "\t", quote = FALSE, row.names = FALSE)
+  calculate_ratios_and_groups(scaling_df),
+  file = snakemake@output[[9]],
+  sep = "\t",
+  quote = FALSE,
+  row.names = FALSE)

--- a/src/minute/summary_plots.R
+++ b/src/minute/summary_plots.R
@@ -279,7 +279,7 @@ ggsave(snakemake@output[[8]],
        units = "cm")
 
 write.table(
-  calculate_ratios_and_groups(scaling_df),
+  calculate_ratios_and_groups(scaling_df) %>% dplyr::select(!c("rep_grp", "is_pool", "rep_number", "reference", "condition")),
   file = snakemake@output[[9]],
   sep = "\t",
   quote = FALSE,

--- a/src/minute/summary_plots.R
+++ b/src/minute/summary_plots.R
@@ -13,10 +13,16 @@ suppressMessages(library(dplyr))
 minute_scaled_grouped_barplot <- function(scaling) {
   scaling <- calculate_ratios_and_groups(scaling)
   
+  bars_df <- scaling[scaling$is_pool == TRUE, ]
+  # Make sure we plot the bars if we have single replicates
+  if(any(scaling$is_pool) == FALSE) {
+      bars_df <- scaling
+  }
+
   ggplot(data = scaling) + 
     aes(x = replace_delims_with_spaces(rep_grp), y = msr, color = scaling_group, fill = scaling_group) +
     geom_point(data = scaling[scaling$is_pool == FALSE, ]) +
-    geom_bar(data = scaling[scaling$is_pool == TRUE, ], stat = "identity", alpha = 0.5) +
+    geom_bar(data = bars_df, stat = "identity", alpha = 0.5) +
     style_minute_barplot() +
     theme(legend.position = "none") +
     scale_x_discrete(labels = scales::label_wrap(20)) +

--- a/src/minute/summary_plots.R
+++ b/src/minute/summary_plots.R
@@ -279,7 +279,7 @@ ggsave(snakemake@output[[8]],
        units = "cm")
 
 write.table(
-  calculate_ratios_and_groups(scaling_df) %>% dplyr::select(!c("rep_grp", "is_pool", "rep_number", "reference", "condition")),
+  calculate_ratios_and_groups(scaling_df) %>% dplyr::select(!c("rep_grp", "is_pool", "rep_number", "reference", "condition")) %>% rename("#reads"="X.reads"),
   file = snakemake@output[[9]],
   sep = "\t",
   quote = FALSE,

--- a/src/minute/summary_plots.R
+++ b/src/minute/summary_plots.R
@@ -281,3 +281,6 @@ ggsave(snakemake@output[[8]],
        dpi = 300,
        units = "cm")
 
+write.table(
+  calculate_ratios_and_groups(read.table(scalinginfo, sep="\t", header = TRUE, comment.char = "")),
+  file = snakemake@output[[9]], sep = "\t", quote = FALSE, row.names = FALSE)


### PR DESCRIPTION
A PR for making improvements in the summary statistics and the summary plots outputted. More specifically:

- Scaled values shown in barplots are now in the `scalinginfo.txt`.
- Size of INR barcodes and barcode representation figures is calculated based on the number of barcodes and libraries in the run, so they scale better with highly multiplexed runs.
- Bars show in barplots if there is only one replicate per pool.
