### PR TITLE
Fix conda environment

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,13 @@
 # minute Changelog
 
+## v0.12.1
+
+### Bug fixes
+
+* Temporary pinned click to version 8.2.1. Recent release 8.2.2 seems to
+introduce an issue with default config values that in turn made MultiQC step
+(multiqc v1.30) fail.
+
 ## v0.12.0
 
 ### Features

--- a/environment.yml
+++ b/environment.yml
@@ -23,3 +23,5 @@ dependencies:
   - r-base >=4.0.0
   - r-ggplot2 >=3.3.0
   - r-dplyr >=1.0.0
+  # click 8.2.2 release crashes MultiQC 1.30
+  - click =8.2.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Bio-Informatics"
 ]
 requires-python = ">=3.7"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
     "ruamel.yaml",
     "xopen",


### PR DESCRIPTION
Recent release of `click` library (8.2.2) seems to give MultiQC config a default value that used to be None, but now it defaults to False, and that makes the report exit with an exception. I pinned `click` to the immediately previous version and that seems to fix the issue for now.